### PR TITLE
[K020] 친구 목록 화면 및 관련 다이얼로그

### DIFF
--- a/PlanJ/.idea/misc.xml
+++ b/PlanJ/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/AppDatabase.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/AppDatabase.kt
@@ -1,7 +1,6 @@
 package com.boostcamp.planj.data.db
 
 import android.content.Context
-import androidx.room.CoroutinesRoom
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
@@ -24,14 +23,14 @@ import kotlinx.coroutines.launch
 abstract class AppDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
 
-    abstract fun scheduleDao() : ScheduleDao
+    abstract fun scheduleDao(): ScheduleDao
 
     abstract fun categoryDao(): CategoryDao
 
 
-        companion object{
+    companion object {
         @Volatile
-        private var INSTANCE : AppDatabase? = null
+        private var INSTANCE: AppDatabase? = null
 
         private fun buildDatabase(context: Context): AppDatabase =
             Room.databaseBuilder(
@@ -55,7 +54,7 @@ abstract class AppDatabase : RoomDatabase() {
                 .build()
 
         fun getInstance(context: Context): AppDatabase =
-            INSTANCE ?: synchronized(this){
+            INSTANCE ?: synchronized(this) {
                 INSTANCE ?: buildDatabase(context).also { INSTANCE = it }
             }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/AppDatabase.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/AppDatabase.kt
@@ -27,7 +27,6 @@ abstract class AppDatabase : RoomDatabase() {
 
     abstract fun categoryDao(): CategoryDao
 
-
     companion object {
         @Volatile
         private var INSTANCE: AppDatabase? = null

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/ScheduleDao.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/ScheduleDao.kt
@@ -23,6 +23,4 @@ interface ScheduleDao {
 
     @Query("SELECT categoryTitle FROM schedules")
     fun getCategories(): Flow<List<String>>
-
-
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/TypeConverter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/TypeConverter.kt
@@ -1,12 +1,10 @@
 package com.boostcamp.planj.data.db
 
 import androidx.room.TypeConverter
+import com.boostcamp.planj.data.model.Alarm
 import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.data.model.User
 import com.google.gson.Gson
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 
 class TypeConverter {
 
@@ -16,6 +14,13 @@ class TypeConverter {
     @TypeConverter
     fun toRepetitionList(value: String?): Repetition? =
         Gson().fromJson(value, Repetition::class.java)
+
+    @TypeConverter
+    fun fromAlarmList(value: Alarm?): String? = Gson().toJson(value)
+
+    @TypeConverter
+    fun toAlarmList(value: String?): Alarm? =
+        Gson().fromJson(value, Alarm::class.java)
 
     @TypeConverter
     fun fromUserList(value: List<User>?): String? = Gson().toJson(value)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/UserDao.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/db/UserDao.kt
@@ -1,13 +1,22 @@
 package com.boostcamp.planj.data.db
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
-import com.boostcamp.planj.data.model.Schedule
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
 import com.boostcamp.planj.data.model.User
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface UserDao {
-    @Insert()
-    fun insertDB(user: User)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertUser(user: User)
+
+    @Query("DELETE FROM users WHERE email = :email")
+    suspend fun deleteUser(email: String)
+
+    @Query("SELECT * FROM users")
+    fun getAllUser(): Flow<List<User>>
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Alarm.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Alarm.kt
@@ -1,0 +1,10 @@
+package com.boostcamp.planj.data.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Alarm(
+    val alarmType: String,
+    val alarmTime: Int
+) : Parcelable

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Schedule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Schedule.kt
@@ -1,7 +1,6 @@
 package com.boostcamp.planj.data.model
 
 import android.os.Parcelable
-import androidx.annotation.Nullable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
@@ -16,10 +15,11 @@ data class Schedule(
     val endTime: String,
     val categoryTitle: String,
     val repetition: Repetition? = null,
+    val alarm: Alarm? = null,
     val members: List<User>,
     val doneMembers: List<User>? = null,
     val location: String? = null,
     val finished: Boolean,
     val failed: Boolean,
 
-) : Parcelable
+    ) : Parcelable

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/User.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/User.kt
@@ -6,7 +6,9 @@ import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@Entity
+@Entity(tableName = "users")
 data class User(
-    @PrimaryKey val id: String
+    val imgUrl: String,
+    val nickname: String,
+    @PrimaryKey val email: String
 ) : Parcelable

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
@@ -2,6 +2,7 @@ package com.boostcamp.planj.data.repository
 
 import com.boostcamp.planj.data.model.Category
 import com.boostcamp.planj.data.model.Schedule
+import com.boostcamp.planj.data.model.User
 import kotlinx.coroutines.flow.Flow
 
 interface MainRepository {
@@ -19,7 +20,14 @@ interface MainRepository {
     suspend fun insertCategory(category: Category)
 
     suspend fun deleteCategory(category: Category)
+
     suspend fun updateCategory(category: Category)
 
     suspend fun getCategoryTitleSchedule(title: String): List<Schedule>
+
+    suspend fun insertUser(email: String)
+
+    suspend fun deleteUser(email: String)
+
+    fun getAllUser(): Flow<List<User>>
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.boostcamp.planj.data.repository
 import com.boostcamp.planj.data.db.AppDatabase
 import com.boostcamp.planj.data.model.Category
 import com.boostcamp.planj.data.model.Schedule
+import com.boostcamp.planj.data.model.User
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -44,5 +45,17 @@ class MainRepositoryImpl @Inject constructor(
 
     override suspend fun getCategoryTitleSchedule(title: String): List<Schedule> {
         return db.categoryDao().getCategoryTitleSchedule(title)
+    }
+
+    override suspend fun insertUser(email: String) {
+        db.userDao().insertUser(User("aaa", email, email))
+    }
+
+    override suspend fun deleteUser(email: String) {
+        db.userDao().deleteUser(email)
+    }
+
+    override fun getAllUser(): Flow<List<User>> {
+        return db.userDao().getAllUser()
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
@@ -6,11 +6,11 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.core.view.isVisible
 import androidx.databinding.BindingAdapter
-import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.R
+import com.boostcamp.planj.data.model.Alarm
 import com.boostcamp.planj.data.model.Category
+import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.ui.login.EmailState
 import com.boostcamp.planj.ui.login.PwdState
@@ -52,8 +52,14 @@ fun TextView.setRepetitionInfo(repetition: Repetition?) {
 }
 
 @BindingAdapter("alarmInfo")
-fun TextView.setAlarmInfo(alarmInfo: String?) {
-    text = if (alarmInfo.isNullOrEmpty()) "설정 안함" else alarmInfo
+fun TextView.setAlarmInfo(alarmInfo: Alarm?) {
+    text = if (alarmInfo != null && alarmInfo.alarmType == "departure") {
+        "출발 시간 ${alarmInfo.alarmTime}분 전"
+    } else if (alarmInfo != null && alarmInfo.alarmType == "end") {
+        "종료 시간 ${alarmInfo.alarmTime}분 전"
+    } else {
+        "설정 안함"
+    }
 }
 
 @BindingAdapter("participation")

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/AddFriendDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/AddFriendDialog.kt
@@ -1,0 +1,79 @@
+package com.boostcamp.planj.ui.main.friendlist
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.DialogFragment
+import com.boostcamp.planj.R
+import com.boostcamp.planj.databinding.DialogAddFriendBinding
+
+class AddFriendDialog : DialogFragment() {
+
+    private var _binding: DialogAddFriendBinding? = null
+    private val binding get() = _binding!!
+
+    private var addFriendDialogListener: AddFriendDialogListener? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = Dialog(requireContext())
+        dialog.window?.setBackgroundDrawableResource(R.drawable.round_r8_main2)
+        return dialog
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogAddFriendBinding.inflate(layoutInflater, container, false)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setListener()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        binding.tietDialogAddFriendEmail.setText("")
+    }
+
+    override fun onDestroy() {
+        _binding = null
+        super.onDestroy()
+    }
+
+    private fun setListener() {
+        with(binding) {
+            tietDialogAddFriendEmail.addTextChangedListener {
+                tilDialogAddFriendLayout.error = null
+            }
+
+            tvDialogAddFriendCancel.setOnClickListener {
+                dismiss()
+            }
+
+            tvDialogAddFriendComplete.setOnClickListener {
+                val email = tietDialogAddFriendEmail.text
+                if (email != null && email.matches(Regex("""^([A-z0-9_\-.]+)@([A-z0-9_\-]+)\.([a-zA-Z]{2,5})$"""))) {
+                    addFriendDialogListener?.onClickComplete(email.toString())
+                    dismiss()
+                } else {
+                    tilDialogAddFriendLayout.error = "이메일 형식이 옳지 않습니다."
+                }
+            }
+        }
+    }
+
+    fun setAddFriendDialogListener(listener: AddFriendDialogListener) {
+        addFriendDialogListener = listener
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/AddFriendDialogListener.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/AddFriendDialogListener.kt
@@ -1,0 +1,6 @@
+package com.boostcamp.planj.ui.main.friendlist
+
+interface AddFriendDialogListener {
+
+    fun onClickComplete(email: String)
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapter.kt
@@ -5,7 +5,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.boostcamp.planj.data.model.User
 
-class FriendAdapter :
+class FriendAdapter(private val listener: FriendClickListener) :
     ListAdapter<User, FriendAdapterViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FriendAdapterViewHolder {
@@ -13,7 +13,7 @@ class FriendAdapter :
     }
 
     override fun onBindViewHolder(holder: FriendAdapterViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), listener)
     }
 
     companion object {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapter.kt
@@ -1,0 +1,30 @@
+package com.boostcamp.planj.ui.main.friendlist
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.boostcamp.planj.data.model.User
+
+class FriendAdapter :
+    ListAdapter<User, FriendAdapterViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FriendAdapterViewHolder {
+        return FriendAdapterViewHolder.from(parent)
+    }
+
+    override fun onBindViewHolder(holder: FriendAdapterViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<User>() {
+            override fun areContentsTheSame(oldItem: User, newItem: User): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areItemsTheSame(oldItem: User, newItem: User): Boolean {
+                return oldItem.email == newItem.email
+            }
+        }
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapterViewHolder.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapterViewHolder.kt
@@ -2,16 +2,30 @@ package com.boostcamp.planj.ui.main.friendlist
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.PopupMenu
 import androidx.recyclerview.widget.RecyclerView
+import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.User
 import com.boostcamp.planj.databinding.ItemFriendBinding
 
 class FriendAdapterViewHolder(private val binding: ItemFriendBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
+    private val friendMenu = PopupMenu(binding.tvFriendMenu.context, binding.tvFriendMenu)
+
     fun bind(user: User, listener: FriendClickListener) {
         binding.user = user
         binding.listener = listener
+
+        friendMenu.setOnMenuItemClickListener {
+            listener.onDelete(user.email)
+            true
+        }
+
+        binding.tvFriendMenu.setOnClickListener {
+            friendMenu.inflate(R.menu.friend_menu)
+            friendMenu.show()
+        }
     }
 
     companion object {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapterViewHolder.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapterViewHolder.kt
@@ -9,8 +9,9 @@ import com.boostcamp.planj.databinding.ItemFriendBinding
 class FriendAdapterViewHolder(private val binding: ItemFriendBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(user: User) {
+    fun bind(user: User, listener: FriendClickListener) {
         binding.user = user
+        binding.listener = listener
     }
 
     companion object {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapterViewHolder.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendAdapterViewHolder.kt
@@ -1,0 +1,27 @@
+package com.boostcamp.planj.ui.main.friendlist
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.boostcamp.planj.data.model.User
+import com.boostcamp.planj.databinding.ItemFriendBinding
+
+class FriendAdapterViewHolder(private val binding: ItemFriendBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(user: User) {
+        binding.user = user
+    }
+
+    companion object {
+        fun from(parent: ViewGroup): FriendAdapterViewHolder {
+            return FriendAdapterViewHolder(
+                ItemFriendBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+        }
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendClickListener.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendClickListener.kt
@@ -1,0 +1,8 @@
+package com.boostcamp.planj.ui.main.friendlist
+
+import com.boostcamp.planj.data.model.User
+
+interface FriendClickListener {
+
+    fun onClick(user: User)
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendClickListener.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendClickListener.kt
@@ -5,4 +5,6 @@ import com.boostcamp.planj.data.model.User
 interface FriendClickListener {
 
     fun onClick(user: User)
+
+    fun onDelete(email: String)
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendInfoDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendInfoDialog.kt
@@ -1,11 +1,13 @@
 package com.boostcamp.planj.ui.main.friendlist
 
+import android.app.Dialog
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.User
 import com.boostcamp.planj.databinding.DialogFriendInfoBinding
 
@@ -13,6 +15,12 @@ class FriendInfoDialog : DialogFragment() {
 
     private var _binding: DialogFriendInfoBinding? = null
     private val binding get() = _binding!!
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = Dialog(requireContext())
+        dialog.window?.setBackgroundDrawableResource(R.drawable.round_white_stroke)
+        return dialog
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendInfoDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendInfoDialog.kt
@@ -1,0 +1,49 @@
+package com.boostcamp.planj.ui.main.friendlist
+
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.boostcamp.planj.data.model.User
+import com.boostcamp.planj.databinding.DialogFriendInfoBinding
+
+class FriendInfoDialog : DialogFragment() {
+
+    private var _binding: DialogFriendInfoBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogFriendInfoBinding.inflate(layoutInflater, container, false)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val user = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelable("user", User::class.java)
+        } else {
+            arguments?.getParcelable("user")
+        }
+        binding.user = user
+        setListener()
+    }
+
+    override fun onDestroy() {
+        _binding = null
+        super.onDestroy()
+    }
+
+    private fun setListener() {
+        binding.ivDialogFriendClose.setOnClickListener {
+            dismiss()
+        }
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListFragment.kt
@@ -67,6 +67,10 @@ class FriendListFragment : Fragment() {
                 friendInfoDialog.arguments = bundle
                 friendInfoDialog.show(childFragmentManager, "친구 정보")
             }
+
+            override fun onDelete(email: String) {
+                viewModel.deleteUser(email)
+            }
         }
         friendAdapter = FriendAdapter(listener)
         binding.rvFriendListFriends.adapter = friendAdapter

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListFragment.kt
@@ -1,7 +1,6 @@
 package com.boostcamp.planj.ui.main.friendlist
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -29,8 +28,12 @@ class FriendListFragment : Fragment() {
         Bundle()
     }
 
-    val friendInfoDialog by lazy {
+    private val friendInfoDialog by lazy {
         FriendInfoDialog()
+    }
+
+    private val addFriendDialog by lazy {
+        AddFriendDialog()
     }
 
     override fun onCreateView(
@@ -48,6 +51,8 @@ class FriendListFragment : Fragment() {
 
         initAdapter()
         setObserver()
+        setListener()
+        setAddDialogListener()
     }
 
     override fun onDestroyView() {
@@ -58,7 +63,6 @@ class FriendListFragment : Fragment() {
     private fun initAdapter() {
         val listener = object : FriendClickListener {
             override fun onClick(user: User) {
-                Log.d("user클릭", user.toString())
                 bundle.putParcelable("user", user)
                 friendInfoDialog.arguments = bundle
                 friendInfoDialog.show(childFragmentManager, "친구 정보")
@@ -76,5 +80,20 @@ class FriendListFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun setListener() {
+        binding.layoutFriendListAdd.setOnClickListener {
+            addFriendDialog.show(childFragmentManager, "친구 추가")
+        }
+    }
+
+    private fun setAddDialogListener() {
+        val listener = object : AddFriendDialogListener {
+            override fun onClickComplete(email: String) {
+                viewModel.addUser(email)
+            }
+        }
+        addFriendDialog.setAddFriendDialogListener(listener)
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListFragment.kt
@@ -5,13 +5,23 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.boostcamp.planj.databinding.FragmentFriendListBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class FriendListFragment : Fragment() {
 
     private var _binding: FragmentFriendListBinding? = null
     private val binding get() = _binding!!
+    val viewModel: FriendListViewModel by viewModels()
 
+    private val friendAdapter = FriendAdapter()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -19,18 +29,29 @@ class FriendListFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentFriendListBinding.inflate(inflater, container, false)
+
         return binding.root
     }
-
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-
+        binding.rvFriendListFriends.adapter = friendAdapter
+        setObserver()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun setObserver() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.userList.collectLatest { userList ->
+                    friendAdapter.submitList(userList)
+                }
+            }
+        }
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListFragment.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.planj.ui.main.friendlist
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.boostcamp.planj.data.model.User
 import com.boostcamp.planj.databinding.FragmentFriendListBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -21,7 +23,15 @@ class FriendListFragment : Fragment() {
     private val binding get() = _binding!!
     val viewModel: FriendListViewModel by viewModels()
 
-    private val friendAdapter = FriendAdapter()
+    private lateinit var friendAdapter: FriendAdapter
+
+    val bundle by lazy {
+        Bundle()
+    }
+
+    val friendInfoDialog by lazy {
+        FriendInfoDialog()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -36,13 +46,26 @@ class FriendListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.rvFriendListFriends.adapter = friendAdapter
+        initAdapter()
         setObserver()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun initAdapter() {
+        val listener = object : FriendClickListener {
+            override fun onClick(user: User) {
+                Log.d("user클릭", user.toString())
+                bundle.putParcelable("user", user)
+                friendInfoDialog.arguments = bundle
+                friendInfoDialog.show(childFragmentManager, "친구 정보")
+            }
+        }
+        friendAdapter = FriendAdapter(listener)
+        binding.rvFriendListFriends.adapter = friendAdapter
     }
 
     private fun setObserver() {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListViewModel.kt
@@ -1,0 +1,34 @@
+package com.boostcamp.planj.ui.main.friendlist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.boostcamp.planj.data.model.User
+import com.boostcamp.planj.data.repository.MainRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FriendListViewModel @Inject constructor(
+    private val mainRepository: MainRepository
+) : ViewModel() {
+
+    val userList: StateFlow<List<User>> = mainRepository.getAllUser()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun addUser(email: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            mainRepository.insertUser(email)
+        }
+    }
+
+    fun deleteUser(email: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            mainRepository.deleteUser(email)
+        }
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialog.kt
@@ -41,6 +41,11 @@ class AlarmSettingDialog : DialogFragment() {
         context?.setDialogSize(this)
     }
 
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+
     private fun setVisibility() {
         with(binding) {
             rgDialogAlarmMode.setOnCheckedChangeListener { _, i ->

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialog.kt
@@ -1,11 +1,13 @@
 package com.boostcamp.planj.ui.schedule
 
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import com.boostcamp.planj.R
+import com.boostcamp.planj.data.model.Alarm
 import com.boostcamp.planj.databinding.DialogAlarmSettingBinding
 
 class AlarmSettingDialog : DialogFragment() {
@@ -28,7 +30,11 @@ class AlarmSettingDialog : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val alarm = arguments?.getString("alarmInfo")
+        val alarm = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelable("alarmInfo", Alarm::class.java)
+        } else {
+            arguments?.getParcelable("alarmInfo")
+        }
 
         setVisibility()
         setListener()
@@ -67,9 +73,9 @@ class AlarmSettingDialog : DialogFragment() {
                 val alarm = if (binding.rbDialogAlarmNo.isChecked) {
                     null
                 } else if (binding.rbDialogAlarmEnd.isChecked) {
-                    "종료 시간 ${binding.etDialogAlarmBeforeEnd.text}분 전"
+                    Alarm("end", binding.etDialogAlarmBeforeEnd.text.toString().toInt())
                 } else {
-                    "출발 시간 ${binding.etDialogAlarmBeforeDeparture.text}분 전"
+                    Alarm("departure", binding.etDialogAlarmBeforeDeparture.text.toString().toInt())
                 }
                 alarmSettingDialogListener?.onClickComplete(alarm)
                 dismiss()
@@ -77,16 +83,16 @@ class AlarmSettingDialog : DialogFragment() {
         }
     }
 
-    private fun setBtnClicked(alarm: String?) {
+    private fun setBtnClicked(alarm: Alarm?) {
         with(binding) {
-            if (alarm == null || alarm == "설정 안함") {
-                rbDialogAlarmNo.isChecked = true
-            } else if (alarm.startsWith("종료")) {
+            if (alarm !=null && alarm.alarmType=="end") {
                 rbDialogAlarmEnd.isChecked = true
-                etDialogAlarmBeforeEnd.setText(alarm.split(" ")[2].dropLast(1))
-            } else {
+                etDialogAlarmBeforeEnd.setText(alarm.alarmTime.toString())
+            } else if (alarm !=null && alarm.alarmType=="departure") {
                 rbDialogAlarmDeparture.isChecked = true
-                etDialogAlarmBeforeEnd.setText(alarm.split(" ")[2].dropLast(1))
+                etDialogAlarmBeforeDeparture.setText(alarm.alarmTime.toString())
+            } else {
+                rbDialogAlarmNo.isChecked = true
             }
         }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialogListener.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialogListener.kt
@@ -1,6 +1,8 @@
 package com.boostcamp.planj.ui.schedule
 
+import com.boostcamp.planj.data.model.Alarm
+
 interface AlarmSettingDialogListener {
 
-    fun onClickComplete(alarm: String?)
+    fun onClickComplete(alarm: Alarm?)
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleDialog.kt
@@ -38,7 +38,6 @@ class ScheduleDialog(
         return binding.root
     }
 
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initAdapter()
@@ -80,6 +79,7 @@ class ScheduleDialog(
                     null,
                     "2023-11-20T18:50:00",
                     category,
+                    null,
                     null,
                     listOf(),
                     null,

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.boostcamp.planj.R
+import com.boostcamp.planj.data.model.Alarm
 import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.databinding.FragmentScheduleBinding
 import com.google.android.material.datepicker.MaterialDatePicker
@@ -184,7 +185,7 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
 
         binding.tvScheduleAlarmSetting.setOnClickListener {
             val bundle = Bundle()
-            bundle.putString("alarmInfo", viewModel.scheduleAlarm.value)
+            bundle.putParcelable("alarmInfo", viewModel.scheduleAlarm.value)
             alarmSettingDialog.arguments = bundle
             alarmSettingDialog.show(childFragmentManager, "알림 설정")
         }
@@ -225,7 +226,7 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
         viewModel.setRepetition(repetition)
     }
 
-    override fun onClickComplete(alarm: String?) {
+    override fun onClickComplete(alarm: Alarm?) {
         viewModel.setAlarm(alarm)
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -2,6 +2,7 @@ package com.boostcamp.planj.ui.schedule
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.boostcamp.planj.data.model.Alarm
 import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.data.model.User
@@ -57,8 +58,8 @@ class ScheduleViewModel @Inject constructor(
     )
     val doneMembers: StateFlow<List<User>?> = _doneMembers
 
-    private val _scheduleAlarm = MutableStateFlow<String?>(null)
-    val scheduleAlarm: StateFlow<String?> = _scheduleAlarm
+    private val _scheduleAlarm = MutableStateFlow<Alarm?>(null)
+    val scheduleAlarm: StateFlow<Alarm?> = _scheduleAlarm
 
     private val _scheduleRepetition = MutableStateFlow<Repetition?>(Repetition("aaa", "daily", 4))
     val scheduleRepetition: StateFlow<Repetition?> = _scheduleRepetition
@@ -105,7 +106,7 @@ class ScheduleViewModel @Inject constructor(
         _scheduleRepetition.value = repetition
     }
 
-    fun setAlarm(alarm: String?) {
+    fun setAlarm(alarm: Alarm?) {
         _scheduleAlarm.value = alarm
     }
 
@@ -127,7 +128,8 @@ class ScheduleViewModel @Inject constructor(
                 startTime = "${scheduleStartDate.value}T${scheduleStartTime.value}",
                 endTime = "${scheduleEndDate.value}T${scheduleEndTime.value}",
                 categoryTitle = scheduleCategory.value,
-                repetition = null,
+                repetition = scheduleRepetition.value,
+                alarm = scheduleAlarm.value,
                 members = listOf(),
                 doneMembers = null,
                 location = locationInfo.value,

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -35,10 +35,26 @@ class ScheduleViewModel @Inject constructor(
     private val _scheduleEndTime = MutableStateFlow<String?>("23:59")
     val scheduleEndTime: StateFlow<String?> = _scheduleEndTime
 
-    private val _members = MutableStateFlow(listOf(User("1111"), User("2222"), User("3333"), User("4444")))
+    private val _members = MutableStateFlow(
+        listOf(
+            User("1111", "1111", "1111"),
+            User("2222", "2222", "2222"),
+            User("3333", "3333", "3333"),
+            User("4444", "4444", "4444"),
+            User("5555", "5555", "5555"),
+            User("6666", "6666", "6666")
+        )
+    )
     val members: StateFlow<List<User>> = _members
 
-    private val _doneMembers = MutableStateFlow<List<User>?>(null)
+    private val _doneMembers = MutableStateFlow<List<User>?>(
+        listOf(
+            User("2222", "2222", "2222"),
+            User("3333", "3333", "3333"),
+            User("5555", "5555", "5555"),
+            User("6666", "6666", "6666")
+        )
+    )
     val doneMembers: StateFlow<List<User>?> = _doneMembers
 
     private val _scheduleAlarm = MutableStateFlow<String?>(null)

--- a/PlanJ/app/src/main/res/layout/dialog_add_friend.xml
+++ b/PlanJ/app/src/main/res/layout/dialog_add_friend.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/dialog_background"
+    android:paddingHorizontal="20dp"
+    android:paddingVertical="20dp">
+
+    <TextView
+        android:id="@+id/tv_dialog_add_friend_title"
+        android:layout_width="300dp"
+        android:layout_height="wrap_content"
+        android:text="@string/add_friend"
+        android:textColor="@color/main3"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_dialog_add_friend_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        app:endIconMode="clear_text"
+        app:helperText="@string/email_condition"
+        app:hintEnabled="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_dialog_add_friend_title">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/tiet_dialog_add_friend_email"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:hint="@string/enter_email"
+            android:imeOptions="actionDone"
+            android:inputType="textEmailAddress"
+            android:maxLines="1"
+            android:textColorHint="@color/dark_gray" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:id="@+id/tv_dialog_add_friend_complete"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/complete"
+        android:textColor="@color/main3"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/til_dialog_add_friend_layout" />
+
+    <TextView
+        android:id="@+id/tv_dialog_add_friend_cancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:text="@string/cancel"
+        android:textColor="@color/red"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toStartOf="@id/tv_dialog_add_friend_complete"
+        app:layout_constraintTop_toTopOf="@id/tv_dialog_add_friend_complete" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/PlanJ/app/src/main/res/layout/dialog_friend_info.xml
+++ b/PlanJ/app/src/main/res/layout/dialog_friend_info.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="user"
+            type="com.boostcamp.planj.data.model.User" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/white">
+
+        <ImageView
+            android:id="@+id/iv_dialog_friend_img"
+            android:layout_width="160dp"
+            android:layout_height="160dp"
+            android:layout_marginHorizontal="60dp"
+            android:layout_marginTop="80dp"
+            android:background="@drawable/round_light_gray"
+            android:contentDescription="@string/user_profile_image"
+            android:scaleType="fitCenter"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/img_logo" />
+
+        <TextView
+            android:id="@+id/tv_dialog_friend_nickname"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@{user.nickname}"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_dialog_friend_img"
+            tools:text="닉네임" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="60dp"
+            android:text="@{user.email}"
+            android:textColor="@color/dark_gray"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_dialog_friend_nickname"
+            tools:text="boostcamp@planj.com" />
+
+        <ImageView
+            android:id="@+id/iv_dialog_friend_close"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_margin="12dp"
+            android:contentDescription="@string/close"
+            android:src="@drawable/ic_close"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/PlanJ/app/src/main/res/layout/fragment_friend_list.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_friend_list.xml
@@ -1,19 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white"
-    >
+    android:background="@color/white">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="친구 목록 화면"
-        app:layout_constraintBottom_toBottomOf="parent"
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar_friends"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:menu="@menu/toolbar_menu">
 
+        <ImageView
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:src="@drawable/img_logo" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/friends"
+            android:textColor="@color/main1"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+    </androidx.appcompat.widget.Toolbar>
+
+    <LinearLayout
+        android:id="@+id/layout_friend_list_add"
+        android:layout_width="0dp"
+        android:layout_height="60dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="8dp"
+        android:background="@drawable/round_r8_stroke_w1"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_friends">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_add" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="친구 추가"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_friend_list_friends"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingVertical="4dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_friend_list_add"
+        tools:listitem="@layout/item_friend" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/PlanJ/app/src/main/res/layout/item_friend.xml
+++ b/PlanJ/app/src/main/res/layout/item_friend.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@null"
+    android:paddingHorizontal="8dp"
+    android:paddingVertical="12dp">
+
+    <ImageView
+        android:id="@+id/iv_friend_img"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_marginStart="8dp"
+        android:contentDescription="@string/user_profile_image"
+        android:scaleType="fitCenter"
+        app:constraintSet="1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/img_logo" />
+
+    <TextView
+        android:id="@+id/tv_friend_nickname"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginStart="16dp"
+        android:textSize="24sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/iv_friend_img"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="닉네임" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/PlanJ/app/src/main/res/layout/item_friend.xml
+++ b/PlanJ/app/src/main/res/layout/item_friend.xml
@@ -1,34 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@null"
-    android:paddingHorizontal="8dp"
-    android:paddingVertical="12dp">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <ImageView
-        android:id="@+id/iv_friend_img"
-        android:layout_width="50dp"
-        android:layout_height="50dp"
-        android:layout_marginStart="8dp"
-        android:contentDescription="@string/user_profile_image"
-        android:scaleType="fitCenter"
-        app:constraintSet="1"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:src="@drawable/img_logo" />
+    <data>
 
-    <TextView
-        android:id="@+id/tv_friend_nickname"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_marginStart="16dp"
-        android:textSize="24sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@id/iv_friend_img"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="닉네임" />
+        <variable
+            name="user"
+            type="com.boostcamp.planj.data.model.User" />
+    </data>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@null"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="12dp">
+
+        <ImageView
+            android:id="@+id/iv_friend_img"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_marginStart="8dp"
+            android:contentDescription="@string/user_profile_image"
+            android:scaleType="fitCenter"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/img_logo" />
+
+        <TextView
+            android:id="@+id/tv_friend_nickname"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginStart="16dp"
+            android:text="@{user.nickname}"
+            android:textSize="24sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/iv_friend_img"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="닉네임" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/PlanJ/app/src/main/res/layout/item_friend.xml
+++ b/PlanJ/app/src/main/res/layout/item_friend.xml
@@ -8,6 +8,10 @@
         <variable
             name="user"
             type="com.boostcamp.planj.data.model.User" />
+
+        <variable
+            name="listener"
+            type="com.boostcamp.planj.ui.main.friendlist.FriendClickListener" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -15,6 +19,7 @@
         android:layout_height="wrap_content"
         android:background="@null"
         android:paddingHorizontal="8dp"
+        android:onClick="@{() -> listener.onClick(user)}"
         android:paddingVertical="12dp">
 
         <ImageView

--- a/PlanJ/app/src/main/res/layout/item_friend.xml
+++ b/PlanJ/app/src/main/res/layout/item_friend.xml
@@ -45,5 +45,18 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="닉네임" />
 
+        <TextView
+            android:id="@+id/tv_friend_menu"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="10dp"
+            android:paddingVertical="5dp"
+            android:text="@string/vertical_ellipsis"
+            android:textAlignment="center"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/PlanJ/app/src/main/res/layout/item_participant.xml
+++ b/PlanJ/app/src/main/res/layout/item_participant.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:textSize="16sp"
-            android:text="@{participant.id}"
+            android:text="@{participant.email}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@id/iv_participant_img"
             app:layout_constraintTop_toTopOf="parent"

--- a/PlanJ/app/src/main/res/menu/friend_menu.xml
+++ b/PlanJ/app/src/main/res/menu/friend_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/item_friend_delete"
+        android:title="@string/delete" />
+</menu>

--- a/PlanJ/app/src/main/res/values/strings.xml
+++ b/PlanJ/app/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
     <string name="close">닫기</string>
     <string name="enter_email">이메일 입력</string>
     <string name="add_friend">친구 추가</string>
+    <string name="delete">삭제</string>
+    <string name="vertical_ellipsis">⋮</string>
     <string-array name="today_list">
         <item>일정</item>
         <item>완료</item>

--- a/PlanJ/app/src/main/res/values/strings.xml
+++ b/PlanJ/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="see_all">전체 보기</string>
     <string name="user_profile_image">프로필 이미지</string>
     <string name="friends">Friends</string>
+    <string name="close">닫기</string>
     <string-array name="today_list">
         <item>일정</item>
         <item>완료</item>

--- a/PlanJ/app/src/main/res/values/strings.xml
+++ b/PlanJ/app/src/main/res/values/strings.xml
@@ -50,6 +50,8 @@
     <string name="user_profile_image">프로필 이미지</string>
     <string name="friends">Friends</string>
     <string name="close">닫기</string>
+    <string name="enter_email">이메일 입력</string>
+    <string name="add_friend">친구 추가</string>
     <string-array name="today_list">
         <item>일정</item>
         <item>완료</item>

--- a/PlanJ/app/src/main/res/values/strings.xml
+++ b/PlanJ/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="participants">참가자</string>
     <string name="see_all">전체 보기</string>
     <string name="user_profile_image">프로필 이미지</string>
+    <string name="friends">Friends</string>
     <string-array name="today_list">
         <item>일정</item>
         <item>완료</item>


### PR DESCRIPTION
### 구현한 기능
- 기존 프로젝트의 User 데이터클래스를 사용해 친구 정보 저장
- FriendListFragment
  - 리사이클러뷰를 이용해 친구 목록을 보여준다.
  - 리사이클러뷰와 친구 추가 다이얼로그에 리스너를 전달한다.
    -> initAdapter()의 listener, setAddDialogListener()
    -> 해당 리스너의 동작은 프래그먼트에서 구현
- FriendListViewModel 
  - users 테이블의 친구를 추가하거나 삭제하는 레포지토리 함수를 호출한다. 이때, users 테이블의 PrimaryKey인 "email(string)"을 이용한다.

### 작동 화면
- 회색 배경 -> ImageView, 이미지 Url을 받아와 보여줄 예정
- 친구 목록, 친구 추가 다이얼로그, 친구 정보 다이얼로그  
  <img src = "https://github.com/boostcampwm2023/and02-PlanJ/assets/101437398/6e8c5150-434c-4bbe-833e-370276059634" width="30%" height="30%">  <img src = "https://github.com/boostcampwm2023/and02-PlanJ/assets/101437398/224cd5c5-f0ff-4af3-8085-d5f4b9390a8e" width="30%" height="30%">  <img src = "https://github.com/boostcampwm2023/and02-PlanJ/assets/101437398/adc41b14-7eff-4908-b71d-bae3bac900e2" width="30%" height="30%">    

- 친구 삭제 메뉴 및 삭제 후  
  <img src = "https://github.com/boostcampwm2023/and02-PlanJ/assets/101437398/9e156876-fb11-4d37-81aa-c5ecb0b667b5" width="30%" height="30%">  <img src = "https://github.com/boostcampwm2023/and02-PlanJ/assets/101437398/ebc17612-cdf1-42e1-83a4-a5d65cc2dbf7" width="30%" height="30%">  
