### PR TITLE
[K026] 네이버 지도를 이용해 주소를 선택하기

### DIFF
--- a/PlanJ/.idea/misc.xml
+++ b/PlanJ/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/PlanJ/app/build.gradle.kts
+++ b/PlanJ/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.com.android.application)
     alias(libs.plugins.org.jetbrains.kotlin.android)
@@ -6,6 +8,11 @@ plugins {
     id("kotlin-parcelize")
     id("androidx.navigation.safeargs.kotlin")
 }
+
+
+// 선언 및 키값을 불러오기
+val properties = Properties()
+properties.load(project.rootProject.file("local.properties").inputStream())
 
 android {
     namespace = "com.boostcamp.planj"
@@ -19,6 +26,19 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        android.buildFeatures.buildConfig = true
+
+        // 프로젝트에서 사용
+        // 타입 - 키 - 값
+        buildConfigField("String", "NAVER_API_KEY", properties["naverKey"] as String)
+        buildConfigField("String", "KAKAO_BASE_URL", properties["kakaoBaseUrl"] as String)
+        buildConfigField("String", "KAKAO_REST_API", properties["kakaoRestApi"] as String)
+
+
+        manifestPlaceholders["NAVER_API_KEY"] = properties["naverKey"] as String
+        manifestPlaceholders["KAKAO_BASE_URL"] = properties["kakaoBaseUrl"] as String
+        manifestPlaceholders["KAKAO_REST_API"] = properties["kakaoRestApi"] as String
     }
 
     buildTypes {
@@ -84,4 +104,7 @@ dependencies {
     implementation(libs.androidx.navigation.ui.ktx)
 
     implementation(libs.kotlinx.serialization.json)
+
+    //네이버 지도
+    implementation(libs.map.sdk)
 }

--- a/PlanJ/app/src/main/AndroidManifest.xml
+++ b/PlanJ/app/src/main/AndroidManifest.xml
@@ -25,7 +25,9 @@
             android:exported="false" />
         <activity
             android:name=".ui.schedule.ScheduleActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize"
+            />
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"

--- a/PlanJ/app/src/main/AndroidManifest.xml
+++ b/PlanJ/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+
     <application
         android:name=".PlanjApplication"
         android:allowBackup="true"
@@ -16,6 +17,9 @@
         android:theme="@style/Theme.PlanJ"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+
+
+
         <activity
             android:name=".ui.search.SearchActivity"
             android:exported="false" />

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/PlanjApplication.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/PlanjApplication.kt
@@ -1,10 +1,16 @@
 package com.boostcamp.planj
 
 import android.app.Application
+import com.naver.maps.map.NaverMapSdk
 import dagger.hilt.android.HiltAndroidApp
 
 
 @HiltAndroidApp
 class PlanjApplication : Application() {
 
+    override fun onCreate() {
+        super.onCreate()
+        NaverMapSdk.getInstance(this).client =
+            NaverMapSdk.NaverCloudPlatformClient(BuildConfig.NAVER_API_KEY)
+    }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/RepositoryModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/RepositoryModule.kt
@@ -4,6 +4,8 @@ import com.boostcamp.planj.data.repository.LoginRepository
 import com.boostcamp.planj.data.repository.LoginRepositoryImpl
 import com.boostcamp.planj.data.repository.MainRepository
 import com.boostcamp.planj.data.repository.MainRepositoryImpl
+import com.boostcamp.planj.data.repository.SearchRepository
+import com.boostcamp.planj.data.repository.SearchRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -22,4 +24,9 @@ abstract class RepositoryModule {
     abstract fun provideMainRepository(
         mainRepositoryImpl: MainRepositoryImpl
     ): MainRepository
+
+    @Binds
+    abstract fun provideSearchRepository(
+        searchRepositoryImpl: SearchRepositoryImpl
+    ) : SearchRepository
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/SearchMapModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/SearchMapModule.kt
@@ -1,0 +1,73 @@
+package com.boostcamp.planj.data.di
+
+import com.boostcamp.planj.BuildConfig
+import com.boostcamp.planj.data.network.KaKaoSearchApi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SearchMapModule {
+
+    @Qualifier
+    @Retention(AnnotationRetention.BINARY)
+    annotation class Map
+
+
+    @Singleton
+    @Provides
+    @Map
+    fun provideInterceptor() : Interceptor {
+        return Interceptor { chain ->
+            var request = chain.request()
+            request = request.newBuilder()
+                .addHeader("Authorization", "KakaoAK ${BuildConfig.KAKAO_REST_API}")
+                .build()
+            chain.proceed(request)
+        }
+    }
+
+    @Singleton
+    @Provides
+    @Map
+    fun provideOkHttpClient(@Map interceptor: Interceptor): OkHttpClient {
+        val httpLoggingInterceptor = HttpLoggingInterceptor()
+            .setLevel(HttpLoggingInterceptor.Level.BODY)
+        return OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .addInterceptor(interceptor)
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    @Map
+    fun provideLoginRetrofit(@Map okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(okHttpClient)
+            .baseUrl(BuildConfig.KAKAO_BASE_URL)
+            .build()
+    }
+
+
+    @Singleton
+    @Provides
+    fun provideRetrofit(@Map retrofit: Retrofit) : KaKaoSearchApi {
+        return retrofit.create(KaKaoSearchApi::class.java)
+    }
+
+
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Address.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Address.kt
@@ -1,0 +1,19 @@
+package com.boostcamp.planj.data.model
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Address(
+    @SerializedName("address_name") val addressName: String,
+    @SerializedName("category_group_code") val categoryGroupCode: String,
+    @SerializedName("category_group_name") val categoryGroupName: String,
+    @SerializedName("category_name") val categoryName: String,
+    @SerializedName("distance") val distance: String,
+    @SerializedName("id") val id: String,
+    @SerializedName("phone") val phone: String,
+    @SerializedName("place_name") val placeName: String,
+    @SerializedName("place_url") val placeUrl: String,
+    @SerializedName("road_address_name") val roadAddressName: String,
+    @SerializedName("x") val x: String,
+    @SerializedName("y") val y: String
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Location.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Location.kt
@@ -1,0 +1,7 @@
+package com.boostcamp.planj.data.model
+
+data class Location(
+    val address : String,
+    val latitude : String,
+    val longitude : String
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Location.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Location.kt
@@ -1,7 +1,13 @@
 package com.boostcamp.planj.data.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+
+@Parcelize
 data class Location(
+    val placeName : String,
     val address : String,
     val latitude : String,
     val longitude : String
-)
+) : Parcelable

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Meta.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Meta.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.planj.data.model
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Meta(
+    @SerializedName("is_end") val isEnd: Boolean,
+    @SerializedName("pageable_count") val pageableCount: Int,
+    @SerializedName("same_name") val sameName: SameName,
+    @SerializedName("total_count") val totalCount: Int
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/SameName.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/SameName.kt
@@ -1,0 +1,10 @@
+package com.boostcamp.planj.data.model
+
+
+import com.google.gson.annotations.SerializedName
+
+data class SameName(
+    @SerializedName("keyword") val keyword: String,
+    @SerializedName("region") val region: List<String>,
+    @SerializedName("selected_region") val selectedRegion: String
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/SearchMap.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/SearchMap.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.planj.data.model
+
+
+import com.google.gson.annotations.SerializedName
+
+data class SearchMap(
+    @SerializedName("documents") val addresses: List<Address>,
+    @SerializedName("meta") val meta: Meta
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/KaKaoSearchApi.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/KaKaoSearchApi.kt
@@ -1,0 +1,15 @@
+package com.boostcamp.planj.data.network
+
+import com.boostcamp.planj.data.model.SearchMap
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface KaKaoSearchApi {
+
+    @GET("local/search/keyword.json")
+    suspend fun searchMap(
+        @Query("query") query : String,
+    ) : SearchMap
+
+
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/SearchRepository.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/SearchRepository.kt
@@ -1,0 +1,10 @@
+package com.boostcamp.planj.data.repository
+
+import com.boostcamp.planj.data.model.Address
+
+interface SearchRepository {
+
+    suspend fun searchMap(
+        query: String,
+    ): List<Address>
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/SearchRepositoryImpl.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/SearchRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.boostcamp.planj.data.repository
+
+import com.boostcamp.planj.data.model.Address
+import com.boostcamp.planj.data.network.KaKaoSearchApi
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SearchRepositoryImpl @Inject constructor(
+    private val api : KaKaoSearchApi
+) : SearchRepository {
+    override suspend fun searchMap(query: String): List<Address> {
+        return api.searchMap(query).addresses
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/MainActivity.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.planj.ui.main
 
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -10,6 +11,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
+import com.boostcamp.planj.BuildConfig
 import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.Category
 import com.boostcamp.planj.databinding.ActivityMainBinding
@@ -29,7 +31,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setJetpackNavigation()

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.databinding.FragmentScheduleBinding
@@ -24,6 +25,8 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
     private var _binding: FragmentScheduleBinding? = null
     private val binding get() = _binding!!
     private val viewModel: ScheduleViewModel by viewModels()
+
+    private val args : ScheduleFragmentArgs by navArgs()
 
     private val repetitionSettingDialog by lazy {
         RepetitionSettingDialog()
@@ -58,6 +61,9 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
 
         binding.viewModel = viewModel
         binding.lifecycleOwner = viewLifecycleOwner
+
+
+        viewModel.setLocation(args.location)
 
         initAdapter()
         setObserver()

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.databinding.FragmentScheduleBinding
@@ -191,6 +192,8 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
 
         binding.ivScheduleMap.setOnClickListener {
             // TODO: 지도 이동
+            val action = ScheduleFragmentDirections.actionScheduleFragmentToScheduleMapFragment(viewModel.locationInfo.value)
+            findNavController().navigate(action)
         }
     }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
@@ -1,0 +1,95 @@
+package com.boostcamp.planj.ui.schedule
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.view.isVisible
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.RecyclerView.ItemDecoration
+import com.boostcamp.planj.databinding.FragmentScheduleMapBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class ScheduleMapFragment : Fragment() {
+
+    private var _binding: FragmentScheduleMapBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ScheduleMapViewModel by viewModels()
+    private lateinit var adapter: ScheduleSearchAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentScheduleMapBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.tilScheduleMapSearch.bringToFront()
+        binding.rvScheduleMapSearchList.bringToFront()
+        binding.layoutSearchDropDown.bringToFront()
+        mapSearch()
+
+        adapter = ScheduleSearchAdapter()
+        binding.rvScheduleMapSearchList.adapter = adapter
+        binding.rvScheduleMapSearchList.addItemDecoration(
+            DividerItemDecoration(
+                requireContext(),
+                DividerItemDecoration.VERTICAL
+            )
+        )
+        adapter.submitList(emptyList())
+
+        setObserver()
+    }
+
+    private fun setObserver() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.searchMap.collectLatest {
+                    if (it.isEmpty()) {
+                        binding.rvScheduleMapSearchList.visibility = View.GONE
+                    } else {
+                        binding.rvScheduleMapSearchList.visibility = View.VISIBLE
+                        adapter.submitList(it)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun mapSearch() {
+        binding.tietScheduleMapSearchInput.addTextChangedListener { text ->
+                text?.let {
+                    val query = it.toString().trim()
+                    if (!viewModel.clicked.value && query.isNotEmpty()) {
+                        viewModel.searchMap(query)
+                    }else{
+                        viewModel.setEmpty()
+                    }
+                }
+        }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
@@ -1,34 +1,45 @@
 package com.boostcamp.planj.ui.schedule
 
+import android.location.Geocoder
+import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
-import androidx.core.view.isVisible
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.RecyclerView.ItemDecoration
 import com.boostcamp.planj.databinding.FragmentScheduleMapBinding
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraAnimation
+import com.naver.maps.map.CameraUpdate
+import com.naver.maps.map.MapView
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.OnMapReadyCallback
+import com.naver.maps.map.overlay.Marker
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import java.util.Locale
 
 @AndroidEntryPoint
-class ScheduleMapFragment : Fragment() {
+class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
 
     private var _binding: FragmentScheduleMapBinding? = null
     private val binding get() = _binding!!
 
     private val viewModel: ScheduleMapViewModel by viewModels()
     private lateinit var adapter: ScheduleSearchAdapter
+    private lateinit var mapView : MapView
+    private lateinit var naverMap : NaverMap
+
+    private val marker = Marker()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -42,12 +53,102 @@ class ScheduleMapFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.tilScheduleMapSearch.bringToFront()
-        binding.rvScheduleMapSearchList.bringToFront()
-        binding.layoutSearchDropDown.bringToFront()
-        mapSearch()
+        mapView = binding.fragmentContainMap
+        mapView.onCreate(savedInstanceState)
+        mapView.getMapAsync(this)
 
-        adapter = ScheduleSearchAdapter()
+        getFocus()
+        mapSearch()
+        initAdapter()
+        setObserver()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView.onStop()
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+        mapView.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
+
+    override fun onMapReady(p0: NaverMap) {
+        this.naverMap = p0
+        naverMap.setOnMapClickListener { _, latLng ->
+            getMarker(latLng)
+        }
+    }
+
+
+    private fun getMarker(latLng: LatLng){
+        marker.map = null
+        marker.position = latLng
+        marker.map = naverMap
+
+        getAddress(latLng)
+    }
+
+    private fun getAddress(latLng: LatLng) {
+        // Geocoder 선언
+        val geocoder = Geocoder(requireContext(), Locale.KOREAN)
+
+        // 안드로이드 API 레벨이 33 이상인 경우
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            geocoder.getFromLocation(
+                latLng.latitude, latLng.longitude, 1
+            ) { address ->
+                if (address.size != 0) {
+                    viewModel.getLocation(latLng, address[0].getAddressLine(0))
+                }
+            }
+        } else { // API 레벨이 33 미만인 경우
+            val addresses = geocoder.getFromLocation(latLng.latitude, latLng.longitude, 1)
+            if (addresses != null) {
+                viewModel.getLocation(latLng, addresses[0].getAddressLine(0))
+            }
+        }
+    }
+    private fun initAdapter() {
+        val clickListener = SearchMapClickListener{
+            binding.tietScheduleMapSearchInput.setText(it.placeName)
+            binding.tietScheduleMapSearchInput.setSelection(it.placeName.length)
+            viewModel.changeClick()
+            val camera = CameraUpdate.scrollTo(LatLng(it.y.toDouble(),it.x.toDouble()))
+                .animate(CameraAnimation.Linear)
+            naverMap.moveCamera(camera)
+            marker.map = null
+            marker.position = LatLng( it.y.toDouble(),it.x.toDouble())
+            marker.map = naverMap
+        }
+
+        adapter = ScheduleSearchAdapter(clickListener)
         binding.rvScheduleMapSearchList.adapter = adapter
         binding.rvScheduleMapSearchList.addItemDecoration(
             DividerItemDecoration(
@@ -56,20 +157,34 @@ class ScheduleMapFragment : Fragment() {
             )
         )
         adapter.submitList(emptyList())
-
-        setObserver()
     }
-
     private fun setObserver() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.searchMap.collectLatest {
-                    if (it.isEmpty()) {
-                        binding.rvScheduleMapSearchList.visibility = View.GONE
+                    if (it.isEmpty() || viewModel.clicked.value) {
+                        adapter.submitList(emptyList())
                     } else {
-                        binding.rvScheduleMapSearchList.visibility = View.VISIBLE
                         adapter.submitList(it)
                     }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.clicked.collectLatest {
+                    if(it) {
+                        adapter.submitList(emptyList())
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.location.collectLatest {
+                    binding.tietScheduleMapSearchInput.setText(it.address)
                 }
             }
         }
@@ -79,17 +194,29 @@ class ScheduleMapFragment : Fragment() {
         binding.tietScheduleMapSearchInput.addTextChangedListener { text ->
                 text?.let {
                     val query = it.toString().trim()
-                    if (!viewModel.clicked.value && query.isNotEmpty()) {
+                    if(viewModel.clicked.value){
+                        viewModel.changeClick()
+                    }
+                    if (query.isNotEmpty()) {
                         viewModel.searchMap(query)
-                    }else{
-                        viewModel.setEmpty()
+                    } else {
+                        adapter.submitList(emptyList())
                     }
                 }
         }
     }
 
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
+    private fun getFocus() {
+        binding.tietScheduleMapSearchInput.requestFocus()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            binding.tietScheduleMapSearchInput.windowInsetsController?.show(
+                WindowInsetsCompat.Type.ime()
+            )
+        } else {
+            activity?.let {
+                WindowInsetsControllerCompat(it.window, binding.tietScheduleMapSearchInput)
+                    .show(WindowInsetsCompat.Type.ime())
+            }
+        }
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
@@ -39,7 +39,7 @@ class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
     private val binding get() = _binding!!
 
     private val viewModel: ScheduleMapViewModel by viewModels()
-    private val args : ScheduleMapFragmentArgs by navArgs()
+    private val args: ScheduleMapFragmentArgs by navArgs()
 
     private lateinit var adapter: ScheduleSearchAdapter
     private lateinit var mapView: MapView
@@ -55,7 +55,6 @@ class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
         return binding.root
     }
 
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         mapView = binding.fragmentContainMap
@@ -63,22 +62,9 @@ class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
         mapView.getMapAsync(this)
         setListener()
         getFocus()
-        mapSearch()
         initAdapter()
         setObserver()
-    }
-
-    private fun setListener() {
-        binding.tilScheduleMapSearch.setEndIconOnClickListener {
-            marker.map = null
-            adapter.submitList(emptyList())
-            binding.tietScheduleMapSearchInput.setText("")
-            viewModel.setLocation(null)
-        }
-        binding.btScheduleMapSelectPlace.setOnClickListener {
-            val action = ScheduleMapFragmentDirections.actionScheduleMapFragmentToScheduleFragment(viewModel.location.value)
-            findNavController().navigate(action)
-        }
+        mapSearch()
     }
 
     override fun onStart() {
@@ -125,6 +111,33 @@ class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
         viewModel.setLocation(args.location)
     }
 
+    private fun setListener() {
+        binding.tilScheduleMapSearch.setEndIconOnClickListener {
+            marker.map = null
+            adapter.submitList(emptyList())
+            binding.tietScheduleMapSearchInput.setText("")
+            viewModel.setLocation(null)
+        }
+        binding.btnScheduleMapSelectPlace.setOnClickListener {
+            val action =
+                ScheduleMapFragmentDirections.actionScheduleMapFragmentToScheduleFragment(viewModel.location.value)
+            findNavController().navigate(action)
+        }
+    }
+
+    private fun getFocus() {
+        binding.tietScheduleMapSearchInput.requestFocus()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            binding.tietScheduleMapSearchInput.windowInsetsController?.show(
+                WindowInsetsCompat.Type.ime()
+            )
+        } else {
+            activity?.let {
+                WindowInsetsControllerCompat(it.window, binding.tietScheduleMapSearchInput)
+                    .show(WindowInsetsCompat.Type.ime())
+            }
+        }
+    }
 
     private fun getMarker(latLng: LatLng) {
         marker.map = null
@@ -248,20 +261,6 @@ class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
                 } else {
                     adapter.submitList(emptyList())
                 }
-            }
-        }
-    }
-
-    private fun getFocus() {
-        binding.tietScheduleMapSearchInput.requestFocus()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            binding.tietScheduleMapSearchInput.windowInsetsController?.show(
-                WindowInsetsCompat.Type.ime()
-            )
-        } else {
-            activity?.let {
-                WindowInsetsControllerCompat(it.window, binding.tietScheduleMapSearchInput)
-                    .show(WindowInsetsCompat.Type.ime())
             }
         }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
@@ -38,7 +38,7 @@ class ScheduleMapViewModel @Inject constructor(
         }
     }
 
-    fun setLocation(location : Location?){
+    fun setLocation(location: Location?) {
         _location.value = location
     }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
@@ -4,7 +4,9 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boostcamp.planj.data.model.Address
+import com.boostcamp.planj.data.model.Location
 import com.boostcamp.planj.data.repository.SearchRepository
+import com.naver.maps.geometry.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,11 +20,14 @@ class ScheduleMapViewModel @Inject constructor(
     private val searchRepository: SearchRepository
 ) : ViewModel() {
 
+    private val _location = MutableStateFlow<Location>(Location("", "", ""))
+    val location: StateFlow<Location> = _location.asStateFlow()
+
     private val _clicked = MutableStateFlow(false)
     val clicked: StateFlow<Boolean> = _clicked.asStateFlow()
 
     private val _searchMap = MutableStateFlow<List<Address>>(emptyList())
-    val searchMap : StateFlow<List<Address>> = _searchMap.asStateFlow()
+    val searchMap: StateFlow<List<Address>> = _searchMap.asStateFlow()
 
     fun searchMap(query: String) {
         viewModelScope.launch {
@@ -34,8 +39,12 @@ class ScheduleMapViewModel @Inject constructor(
         }
     }
 
-    fun setEmpty(){
-        _searchMap.value = emptyList()
-        _clicked.value = false
+    fun getLocation(latLng: LatLng, addressName : String){
+        _location.value = Location(addressName, latLng.latitude.toString(), latLng.longitude.toString())
+    }
+
+
+    fun changeClick() {
+        _clicked.value = !_clicked.value
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.boostcamp.planj.data.model.Address
 import com.boostcamp.planj.data.model.Location
 import com.boostcamp.planj.data.repository.SearchRepository
-import com.naver.maps.geometry.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,8 +19,8 @@ class ScheduleMapViewModel @Inject constructor(
     private val searchRepository: SearchRepository
 ) : ViewModel() {
 
-    private val _location = MutableStateFlow<Location>(Location("", "", ""))
-    val location: StateFlow<Location> = _location.asStateFlow()
+    private val _location = MutableStateFlow<Location?>(null)
+    val location: StateFlow<Location?> = _location.asStateFlow()
 
     private val _clicked = MutableStateFlow(false)
     val clicked: StateFlow<Boolean> = _clicked.asStateFlow()
@@ -39,8 +38,8 @@ class ScheduleMapViewModel @Inject constructor(
         }
     }
 
-    fun getLocation(latLng: LatLng, addressName : String){
-        _location.value = Location(addressName, latLng.latitude.toString(), latLng.longitude.toString())
+    fun setLocation(location : Location?){
+        _location.value = location
     }
 
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
@@ -1,0 +1,41 @@
+package com.boostcamp.planj.ui.schedule
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.boostcamp.planj.data.model.Address
+import com.boostcamp.planj.data.repository.SearchRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.lang.Exception
+import javax.inject.Inject
+
+@HiltViewModel
+class ScheduleMapViewModel @Inject constructor(
+    private val searchRepository: SearchRepository
+) : ViewModel() {
+
+    private val _clicked = MutableStateFlow(false)
+    val clicked: StateFlow<Boolean> = _clicked.asStateFlow()
+
+    private val _searchMap = MutableStateFlow<List<Address>>(emptyList())
+    val searchMap : StateFlow<List<Address>> = _searchMap.asStateFlow()
+
+    fun searchMap(query: String) {
+        viewModelScope.launch {
+            try {
+                _searchMap.value = searchRepository.searchMap(query)
+            } catch (e: Exception) {
+                Log.d("PLANJDEBUG", "SearchMap Error")
+            }
+        }
+    }
+
+    fun setEmpty(){
+        _searchMap.value = emptyList()
+        _clicked.value = false
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapter.kt
@@ -1,0 +1,41 @@
+package com.boostcamp.planj.ui.schedule
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.boostcamp.planj.data.model.Address
+
+class ScheduleSearchAdapter : ListAdapter<Address, ScheduleSearchAdapterViewHolder>(diffUtil){
+
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): ScheduleSearchAdapterViewHolder {
+        return ScheduleSearchAdapterViewHolder.from(parent)
+    }
+
+    override fun onBindViewHolder(holder: ScheduleSearchAdapterViewHolder, position: Int) {
+        holder.onBind(currentList[position])
+    }
+
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<Address>() {
+            override fun areContentsTheSame(
+                oldItem: Address,
+                newItem: Address
+            ): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areItemsTheSame(
+                oldItem: Address,
+                newItem: Address
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+        }
+    }
+
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapter.kt
@@ -5,8 +5,8 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.boostcamp.planj.data.model.Address
 
-class ScheduleSearchAdapter(private val onClickListener: SearchMapClickListener) : ListAdapter<Address, ScheduleSearchAdapterViewHolder>(diffUtil){
-
+class ScheduleSearchAdapter(private val onClickListener: SearchMapClickListener) :
+    ListAdapter<Address, ScheduleSearchAdapterViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -18,7 +18,6 @@ class ScheduleSearchAdapter(private val onClickListener: SearchMapClickListener)
     override fun onBindViewHolder(holder: ScheduleSearchAdapterViewHolder, position: Int) {
         holder.onBind(currentList[position], onClickListener)
     }
-
 
     companion object {
         val diffUtil = object : DiffUtil.ItemCallback<Address>() {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapter.kt
@@ -5,7 +5,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.boostcamp.planj.data.model.Address
 
-class ScheduleSearchAdapter : ListAdapter<Address, ScheduleSearchAdapterViewHolder>(diffUtil){
+class ScheduleSearchAdapter(private val onClickListener: SearchMapClickListener) : ListAdapter<Address, ScheduleSearchAdapterViewHolder>(diffUtil){
 
 
     override fun onCreateViewHolder(
@@ -16,7 +16,7 @@ class ScheduleSearchAdapter : ListAdapter<Address, ScheduleSearchAdapterViewHold
     }
 
     override fun onBindViewHolder(holder: ScheduleSearchAdapterViewHolder, position: Int) {
-        holder.onBind(currentList[position])
+        holder.onBind(currentList[position], onClickListener)
     }
 
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapterViewHolder.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapterViewHolder.kt
@@ -1,0 +1,28 @@
+package com.boostcamp.planj.ui.schedule
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.boostcamp.planj.data.model.Address
+import com.boostcamp.planj.databinding.ItemSearchMapBinding
+
+class ScheduleSearchAdapterViewHolder(private val binding: ItemSearchMapBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun onBind(item : Address){
+        binding.address = item
+    }
+
+
+    companion object {
+        fun from(parent: ViewGroup): ScheduleSearchAdapterViewHolder {
+            return ScheduleSearchAdapterViewHolder(
+                ItemSearchMapBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+        }
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapterViewHolder.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapterViewHolder.kt
@@ -9,8 +9,11 @@ import com.boostcamp.planj.databinding.ItemSearchMapBinding
 class ScheduleSearchAdapterViewHolder(private val binding: ItemSearchMapBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun onBind(item : Address){
+    fun onBind(item : Address, onClickListener: SearchMapClickListener){
         binding.address = item
+        itemView.setOnClickListener {
+            onClickListener.onClick(item)
+        }
     }
 
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapterViewHolder.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleSearchAdapterViewHolder.kt
@@ -16,7 +16,6 @@ class ScheduleSearchAdapterViewHolder(private val binding: ItemSearchMapBinding)
         }
     }
 
-
     companion object {
         fun from(parent: ViewGroup): ScheduleSearchAdapterViewHolder {
             return ScheduleSearchAdapterViewHolder(

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -2,6 +2,7 @@ package com.boostcamp.planj.ui.schedule
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.boostcamp.planj.data.model.Location
 import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.data.model.User
@@ -46,7 +47,7 @@ class ScheduleViewModel @Inject constructor(
 
     private val _scheduleRepetition = MutableStateFlow<Repetition?>(Repetition("aaa", "daily", 4))
     val scheduleRepetition: StateFlow<Repetition?> = _scheduleRepetition
-    val locationInfo = MutableStateFlow<String?>(null)
+    val locationInfo = MutableStateFlow<Location?>(null)
     val userMemo = MutableStateFlow<String?>(null)
 
     private val dateFormat = SimpleDateFormat("yyyy/MM/dd")
@@ -93,6 +94,10 @@ class ScheduleViewModel @Inject constructor(
         _scheduleAlarm.value = alarm
     }
 
+    fun setLocation(location: Location?){
+        locationInfo.value = location
+    }
+
     fun startEditingSchedule() {
         _isEditMode.value = true
     }
@@ -114,7 +119,7 @@ class ScheduleViewModel @Inject constructor(
                 repetition = null,
                 members = listOf(),
                 doneMembers = null,
-                location = locationInfo.value,
+                location = locationInfo.value?.placeName,
                 finished = false,
                 failed = false
             )

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/SearchMapClickListener.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/SearchMapClickListener.kt
@@ -1,0 +1,7 @@
+package com.boostcamp.planj.ui.schedule
+
+import com.boostcamp.planj.data.model.Address
+
+fun interface SearchMapClickListener {
+    fun onClick(address : Address)
+}

--- a/PlanJ/app/src/main/res/drawable/round_search_background.xml
+++ b/PlanJ/app/src/main/res/drawable/round_search_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/main2"/>
+
+    <corners android:bottomLeftRadius="8dp" android:bottomRightRadius="8dp"/>
+</shape>

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -427,7 +427,7 @@
                     android:inputType="text"
                     android:maxLines="1"
                     android:paddingHorizontal="24dp"
-                    android:text="@{viewModel.locationInfo}"
+                    android:text="@{viewModel.locationInfo.placeName}"
                     android:textColor="@color/selector_text_color"
                     android:textSize="16sp"
                     app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"

--- a/PlanJ/app/src/main/res/layout/fragment_schedule_map.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule_map.xml
@@ -17,6 +17,7 @@
         app:boxBackgroundColor="@color/main2"
         app:endIconMode="clear_text"
         android:layout_margin="16dp"
+        android:elevation="1dp"
         >
 
         <com.google.android.material.textfield.TextInputEditText
@@ -37,6 +38,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/til_schedule_map_search"
+        android:elevation="1dp"
         >
 
         <androidx.recyclerview.widget.RecyclerView
@@ -64,13 +66,31 @@
         app:layout_constraintBottom_toBottomOf="parent"
         >
 
-        <androidx.fragment.app.FragmentContainerView
+        <com.naver.maps.map.MapView
             android:id="@+id/fragment_contain_map"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-
-            android:name="com.naver.maps.map.MapFragment" />
+            android:touchscreenBlocksFocus="true"
+            />
     </FrameLayout>
+
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/bt_schedule_map_select_place"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="위치 등록하기"
+        android:background="@drawable/round_r8_main1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:textStyle="bold"
+        android:textColor="@color/main2"
+        android:layout_marginBottom="16dp"
+        android:layout_marginHorizontal="16dp"
+        android:padding="16dp"
+        android:elevation="1dp"
+        />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/PlanJ/app/src/main/res/layout/fragment_schedule_map.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule_map.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_schedule_map_search"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:startIconDrawable="@drawable/ic_search"
+        style="@style/ThemeOverlay.Material3.TextInputEditText.FilledBox"
+        app:boxBackgroundColor="@color/main2"
+        app:endIconMode="clear_text"
+        android:layout_margin="16dp"
+        >
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/tiet_schedule_map_search_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            android:imeOptions="actionDone"
+            android:maxLines="1"
+            />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <FrameLayout
+        android:id="@+id/layout_search_drop_down"
+        android:layout_width="0dp"
+        android:layout_height="250dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/til_schedule_map_search"
+        >
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_schedule_map_search_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/til_schedule_map_search"
+            android:layout_marginHorizontal="16dp"
+            android:background="@drawable/round_search_background"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            android:scrollbars="vertical"
+            />
+
+    </FrameLayout>
+
+
+    <FrameLayout
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        >
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fragment_contain_map"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+
+            android:name="com.naver.maps.map.MapFragment" />
+    </FrameLayout>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/PlanJ/app/src/main/res/layout/fragment_schedule_map.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule_map.xml
@@ -1,33 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/til_schedule_map_search"
+        style="@style/ThemeOverlay.Material3.TextInputEditText.FilledBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:startIconDrawable="@drawable/ic_search"
-        style="@style/ThemeOverlay.Material3.TextInputEditText.FilledBox"
-        app:boxBackgroundColor="@color/main2"
-        app:endIconMode="clear_text"
         android:layout_margin="16dp"
         android:elevation="1dp"
-        >
+        app:boxBackgroundColor="@color/main2"
+        app:endIconMode="clear_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:startIconDrawable="@drawable/ic_search">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/tiet_schedule_map_search_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="text"
             android:imeOptions="actionDone"
-            android:maxLines="1"
-            />
+            android:inputType="text"
+            android:maxLines="1" />
 
     </com.google.android.material.textfield.TextInputLayout>
 
@@ -35,24 +33,22 @@
         android:id="@+id/layout_search_drop_down"
         android:layout_width="0dp"
         android:layout_height="250dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/til_schedule_map_search"
         android:elevation="1dp"
-        >
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/til_schedule_map_search">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_schedule_map_search_list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/til_schedule_map_search"
             android:layout_marginHorizontal="16dp"
             android:background="@drawable/round_search_background"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             android:scrollbars="vertical"
-            />
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/til_schedule_map_search" />
 
     </FrameLayout>
 
@@ -60,37 +56,34 @@
     <FrameLayout
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        >
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.naver.maps.map.MapView
             android:id="@+id/fragment_contain_map"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:touchscreenBlocksFocus="true"
-            />
+            android:touchscreenBlocksFocus="true" />
     </FrameLayout>
 
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/bt_schedule_map_select_place"
+        android:id="@+id/btn_schedule_map_select_place"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="위치 등록하기"
-        android:background="@drawable/round_r8_main1"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:textStyle="bold"
-        android:textColor="@color/main2"
-        android:layout_marginBottom="16dp"
         android:layout_marginHorizontal="16dp"
-        android:padding="16dp"
+        android:layout_marginBottom="16dp"
+        android:background="@drawable/round_r8_main1"
         android:elevation="1dp"
-        />
+        android:padding="16dp"
+        android:text="위치 등록하기"
+        android:textColor="@color/main2"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/PlanJ/app/src/main/res/layout/item_search_map.xml
+++ b/PlanJ/app/src/main/res/layout/item_search_map.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="address"
+            type="com.boostcamp.planj.data.model.Address" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_place_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@{address.placeName}"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_address_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@{address.addressName}"
+            android:textColor="@color/black"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_place_name"
+
+            />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/PlanJ/app/src/main/res/navigation/schedule_nav.xml
+++ b/PlanJ/app/src/main/res/navigation/schedule_nav.xml
@@ -7,5 +7,25 @@
     <fragment
         android:id="@+id/scheduleFragment"
         android:name="com.boostcamp.planj.ui.schedule.ScheduleFragment"
-        android:label="ScheduleFragment" />
+        android:label="ScheduleFragment" >
+        <action
+            android:id="@+id/action_scheduleFragment_to_scheduleMapFragment"
+            app:destination="@id/scheduleMapFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/scheduleMapFragment"
+        android:name="com.boostcamp.planj.ui.schedule.ScheduleMapFragment"
+        android:label="ScheduleMapFragment" >
+        <argument
+            android:name="location"
+            app:argType="string"
+            app:nullable="true" />
+        <action
+            android:id="@+id/action_scheduleMapFragment_to_scheduleMapSearchFragment"
+            app:destination="@id/scheduleMapSearchFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/scheduleMapSearchFragment"
+        android:name="com.boostcamp.planj.ui.schedule.ScheduleMapSearchFragment"
+        android:label="ScheduleMapSearchFragment" />
 </navigation>

--- a/PlanJ/app/src/main/res/navigation/schedule_nav.xml
+++ b/PlanJ/app/src/main/res/navigation/schedule_nav.xml
@@ -10,22 +10,28 @@
         android:label="ScheduleFragment" >
         <action
             android:id="@+id/action_scheduleFragment_to_scheduleMapFragment"
+            app:popUpToInclusive="true"
             app:destination="@id/scheduleMapFragment" />
+        <argument
+            android:name="location"
+            app:argType="com.boostcamp.planj.data.model.Location"
+            app:nullable="true"
+            android:defaultValue="@null" />
     </fragment>
     <fragment
         android:id="@+id/scheduleMapFragment"
         android:name="com.boostcamp.planj.ui.schedule.ScheduleMapFragment"
-        android:label="ScheduleMapFragment" >
+        android:label="ScheduleMapFragment"
+        >
+        <action
+            android:id="@+id/action_scheduleMapFragment_to_scheduleFragment"
+            app:popUpToInclusive="true"
+            app:popUpTo="@id/scheduleFragment"
+            app:destination="@id/scheduleFragment" />
         <argument
             android:name="location"
-            app:argType="string"
-            app:nullable="true" />
-        <action
-            android:id="@+id/action_scheduleMapFragment_to_scheduleMapSearchFragment"
-            app:destination="@id/scheduleMapSearchFragment" />
+            app:argType="com.boostcamp.planj.data.model.Location"
+            app:nullable="true"
+            android:defaultValue="@null" />
     </fragment>
-    <fragment
-        android:id="@+id/scheduleMapSearchFragment"
-        android:name="com.boostcamp.planj.ui.schedule.ScheduleMapSearchFragment"
-        android:label="ScheduleMapSearchFragment" />
 </navigation>

--- a/PlanJ/gradle.properties
+++ b/PlanJ/gradle.properties
@@ -15,6 +15,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Enables namespacing of each library's R class so that its R class includes only the

--- a/PlanJ/gradle/libs.versions.toml
+++ b/PlanJ/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ hiltAndroid = "2.44"
 junit = "4.13.2"
 kotlinxSerializationJson = "1.6.1"
 lifecycleViewmodelKtx = "2.6.2"
+mapSdk = "3.17.0"
 material = "1.10.0"
 jetbrainsGradlePlugin = "1.8.0"
 hiltGradlePlugin = "2.44"
@@ -40,6 +41,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+map-sdk = { module = "com.naver.maps:map-sdk", version.ref = "mapSdk" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }

--- a/PlanJ/settings.gradle.kts
+++ b/PlanJ/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://naver.jfrog.io/artifactory/maven/")
     }
 }
 


### PR DESCRIPTION
  - [X] 네이버 지도 연결
  - [X] 카카오 검색 기능 사용하기 위해 SearchMapModule 생성
  - [X] 검색 기능을 이용해 검색할 때마다 해당 관련되 검색 주소 보여주기
  - [X] 네이버 지도 터치할 때도 주소와 마커 생기게 구현하기
  - [X] 키보드가 올라가도 버튼이 항상 보이게 구현
  - [X] 일정 화면이랑 지도 화면 데이터 연결(Location 데이터 클래스 새로 생성)
  
+ 네이버 지도 연결, 상단에는 검색, 아래에는 주소 추가 버튼으로 Ui 구현
    + 시크릿으로 클라이언트 ID 저장하고 맵을 사용
    + 위에는 검색, 아래에는 등록  버튼을 추가하도록 구현(아직 선택하지 앖았을 때 어떻게 처리할 지 몰라서 구현 안함)
        + 그냥 빈 값으로 하기(null)
        + 아니면 등록이 안됐다고 토스트 메시지 띄우기


<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/8d0d182a-b5bf-46fb-b991-f9b114eb7549" width=300 height=600/>

+ 카카오 검색 기능을 활용해 검색을 할 때마다 요청을 받아와 아래 검색 관련 목록들을 보여주도록 기능 구현
    + 아래 검색 목록을 클릭 시 해당 지도록 이동하며 마커가 생기게 구현

<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/1d1221bb-d5ae-4357-8c92-a120f8c080d0" width=300 height=600/>

<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/c9f0bfff-5ba9-471f-a309-2f3b81f972d4" width=300 height=600/>


+ 검색 이외에도 지도 터치했을 때도 있으면 좋을 것 같아 터치 했을 때 해당 주소를 보여준다.
    + 해당 주소를 눌렀을 때도 근처 가게 이름이나 특정 주소가 있으면 화면을 보여주는 방식으로 구현

<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/ca86a0bf-8ba0-4998-8638-a5acf65a0087" width=300 height=600/>


+ 위치 등록 누를 시 일정 부분에 설정된 주소가 보이도록 구현, 다시 주소를 누르면 위치된 값으로 이동

   <img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/14d75c3d-26aa-4808-b417-0590c734573b" width=300 height=600/>


## 고민
 + 마커 설정을 안해도 위치 등록시 어떻게 할 것인가
        +  그냥 null값 보내기
        +  토스트 메시지를 띄워서 입력 받도록 한다.(나가는거는 뒤로가기로만 한다)

+ 위치 등록하면 데이터가 잘 넘어가는데 텍스트뷰 크기가 너무 작아서 주소가 짤려서 보인다. 이를 조금 안짤리게 처리를 했으면 좋을 것 같다.
     + 생각한 방법으로는 아래에 주소와, 지도를 같이 보여주는 방식으로 생각 

