### PR TITLE
[K026] 로그인, 메인 모듈 분리,도착 위치 설정하기

### DIFF
--- a/PlanJ/app/build.gradle.kts
+++ b/PlanJ/app/build.gradle.kts
@@ -37,6 +37,7 @@ android {
         buildConfigField("String", "DATA_STORE_NAME", properties["dateStoreName"] as String)
         buildConfigField("String", "BASE_URL", properties["baseUrl"] as String)
         buildConfigField("String", "USER", properties["user"] as String)
+        buildConfigField("String", "NAVER_CLIENT_SECRET", properties["naverClientSecret"] as String)
 
 
         manifestPlaceholders["NAVER_API_KEY"] = properties["naverKey"] as String
@@ -45,6 +46,7 @@ android {
         manifestPlaceholders["DATA_STORE_NAME"] = properties["dateStoreName"] as String
         manifestPlaceholders["BASE_URL"] = properties["baseUrl"] as String
         manifestPlaceholders["USER"] = properties["user"] as String
+        manifestPlaceholders["NAVER_CLIENT_SECRET"] = properties["naverClientSecret"] as String
     }
 
     buildTypes {

--- a/PlanJ/app/build.gradle.kts
+++ b/PlanJ/app/build.gradle.kts
@@ -36,6 +36,7 @@ android {
         buildConfigField("String", "KAKAO_REST_API", properties["kakaoRestApi"] as String)
         buildConfigField("String", "DATA_STORE_NAME", properties["dateStoreName"] as String)
         buildConfigField("String", "BASE_URL", properties["baseUrl"] as String)
+        buildConfigField("String", "USER", properties["user"] as String)
 
 
         manifestPlaceholders["NAVER_API_KEY"] = properties["naverKey"] as String
@@ -43,6 +44,7 @@ android {
         manifestPlaceholders["KAKAO_REST_API"] = properties["kakaoRestApi"] as String
         manifestPlaceholders["DATA_STORE_NAME"] = properties["dateStoreName"] as String
         manifestPlaceholders["BASE_URL"] = properties["baseUrl"] as String
+        manifestPlaceholders["USER"] = properties["user"] as String
     }
 
     buildTypes {

--- a/PlanJ/app/src/main/AndroidManifest.xml
+++ b/PlanJ/app/src/main/AndroidManifest.xml
@@ -31,17 +31,17 @@
             android:exported="true"
             android:windowSoftInputMode="adjustPan"
             >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
 
         </activity>
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true">
 
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
 
         </activity>
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/LogInModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/LogInModule.kt
@@ -1,0 +1,54 @@
+package com.boostcamp.planj.data.di
+
+import com.boostcamp.planj.BuildConfig
+import com.boostcamp.planj.data.network.LoginApi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LogInModule {
+
+    @Qualifier
+    @Retention(AnnotationRetention.BINARY)
+    annotation class Login
+
+    //retrofit
+    @Singleton
+    @Provides
+    @Login
+    fun provideOkHttpClient(): OkHttpClient {
+        val httpLoggingInterceptor = HttpLoggingInterceptor()
+            .setLevel(HttpLoggingInterceptor.Level.BODY)
+        return OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    @Login
+    fun provideRetrofitInstance(@Login okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(okHttpClient)
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    fun provideService(@Login retrofit: Retrofit): LoginApi {
+        return retrofit.create(LoginApi::class.java)
+    }
+
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/NaverDirectionModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/NaverDirectionModule.kt
@@ -1,74 +1,77 @@
 package com.boostcamp.planj.data.di
 
 import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.boostcamp.planj.BuildConfig
-import com.boostcamp.planj.data.network.KaKaoSearchApi
+import com.boostcamp.planj.data.network.MainApi
+import com.boostcamp.planj.data.network.NaverApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.create
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
-
 @Module
 @InstallIn(SingletonComponent::class)
-object SearchMapModule {
+object NaverDirectionModule {
 
     @Qualifier
     @Retention(AnnotationRetention.BINARY)
-    annotation class Map
-
+    annotation class Naver
 
     @Singleton
     @Provides
-    @Map
-    fun provideInterceptor() : Interceptor {
+    @Naver
+    fun provideInterceptor(): Interceptor {
         return Interceptor { chain ->
             var request = chain.request()
             request = request.newBuilder()
-                .addHeader("Authorization", "KakaoAK ${BuildConfig.KAKAO_REST_API}")
+                .addHeader("X-NCP-APIGW-API-KEY-ID", BuildConfig.NAVER_API_KEY)
+                .addHeader("X-NCP-APIGW-API-KEY", BuildConfig.NAVER_CLIENT_SECRET)
                 .build()
             chain.proceed(request)
         }
     }
 
+
+    //retrofit
     @Singleton
     @Provides
-    @Map
-    fun provideOkHttpClient(@Map interceptor: Interceptor): OkHttpClient {
+    @Naver
+    fun provideOkHttpClient(@Naver interceptor: Interceptor): OkHttpClient {
         val httpLoggingInterceptor = HttpLoggingInterceptor()
             .setLevel(HttpLoggingInterceptor.Level.BODY)
         return OkHttpClient.Builder()
-            .addInterceptor(httpLoggingInterceptor)
             .addInterceptor(interceptor)
+            .addInterceptor(httpLoggingInterceptor)
             .build()
     }
 
     @Singleton
     @Provides
-    @Map
-    fun provideLoginRetrofit(@Map okHttpClient: OkHttpClient): Retrofit {
+    @Naver
+    fun provideRetrofitInstance(@Naver okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
+            .baseUrl("https://naveropenapi.apigw.ntruss.com/")
             .addConverterFactory(GsonConverterFactory.create())
             .client(okHttpClient)
-            .baseUrl(BuildConfig.KAKAO_BASE_URL)
             .build()
     }
 
-
     @Singleton
     @Provides
-    fun provideRetrofit(@Map retrofit: Retrofit) : KaKaoSearchApi {
-        return retrofit.create(KaKaoSearchApi::class.java)
+    fun provideService(@Naver retrofit: Retrofit): NaverApi {
+        return retrofit.create(NaverApi::class.java)
     }
-
-
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/RepositoryModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/RepositoryModule.kt
@@ -4,6 +4,8 @@ import com.boostcamp.planj.data.repository.LoginRepository
 import com.boostcamp.planj.data.repository.LoginRepositoryImpl
 import com.boostcamp.planj.data.repository.MainRepository
 import com.boostcamp.planj.data.repository.MainRepositoryImpl
+import com.boostcamp.planj.data.repository.NaverRepository
+import com.boostcamp.planj.data.repository.NaverRepositoryImpl
 import com.boostcamp.planj.data.repository.SearchRepository
 import com.boostcamp.planj.data.repository.SearchRepositoryImpl
 import dagger.Binds
@@ -29,4 +31,10 @@ abstract class RepositoryModule {
     abstract fun provideSearchRepository(
         searchRepositoryImpl: SearchRepositoryImpl
     ) : SearchRepository
+
+
+    @Binds
+    abstract fun provideNaverRepository(
+        naverRepository: NaverRepositoryImpl
+    ) : NaverRepository
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/SearchMapModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/SearchMapModule.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.planj.data.di
 
+import android.util.Log
 import com.boostcamp.planj.BuildConfig
 import com.boostcamp.planj.data.network.KaKaoSearchApi
 import dagger.Module
@@ -30,6 +31,7 @@ object SearchMapModule {
     @Provides
     @Map
     fun provideInterceptor() : Interceptor {
+        Log.d("PLANJDEBUG", "provideInterceptor for map ")
         return Interceptor { chain ->
             var request = chain.request()
             request = request.newBuilder()

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostCategoryBody.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostCategoryBody.kt
@@ -3,7 +3,5 @@ package com.boostcamp.planj.data.model
 import com.google.gson.annotations.SerializedName
 
 data class PostCategoryBody(
-    @SerializedName("userUuid") val userUuid : String,
     @SerializedName("categoryName") val categoryName : String,
-    @SerializedName("createdAt") val createdAt: String
 )

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostCategoryResponse.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostCategoryResponse.kt
@@ -6,6 +6,5 @@ data class CategoryData(val categoryUuid : String)
 
 data class PostCategoryResponse(
     @SerializedName("message") val message : String,
-    @SerializedName("statusCode") val statusCode : String,
     @SerializedName("data") val categoryData : CategoryData,
 )

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostScheduleBody.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostScheduleBody.kt
@@ -3,7 +3,6 @@ package com.boostcamp.planj.data.model
 import com.google.gson.annotations.SerializedName
 
 data class PostScheduleBody(
-    @SerializedName("userUuid") val userUuid : String,
     @SerializedName("categoryUuid") val categoryUuid : String,
     @SerializedName("title") val title : String,
     @SerializedName("endAt") val endAt : String

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostScheduleResponse.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostScheduleResponse.kt
@@ -6,6 +6,5 @@ data class ScheduleData(val scheduleUuid : String)
 
 data class PostScheduleResponse(
     @SerializedName("message") val message : String,
-    @SerializedName("statusCode") val statusCode : String,
     @SerializedName("data") val data : ScheduleData
 )

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Goal.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Goal.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.planj.data.model.naver
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Goal(
+    @SerializedName("dir") val dir: Int,
+    @SerializedName("location") val location: List<Double>
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Guide.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Guide.kt
@@ -1,0 +1,12 @@
+package com.boostcamp.planj.data.model.naver
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Guide(
+    @SerializedName("distance") val distance: Int,
+    @SerializedName("duration") val duration: Int,
+    @SerializedName("instructions") val instructions: String,
+    @SerializedName("pointIndex") val pointIndex: Int,
+    @SerializedName("type") val type: Int
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/NaverResponse.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/NaverResponse.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.planj.data.model.naver
+
+
+import com.google.gson.annotations.SerializedName
+
+data class NaverResponse(
+    @SerializedName("code") val code: Int,
+    @SerializedName("currentDateTime") val currentDateTime: String,
+    @SerializedName("message") val message: String,
+    @SerializedName("route") val route: Route
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Route.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Route.kt
@@ -1,0 +1,8 @@
+package com.boostcamp.planj.data.model.naver
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Route(
+    @SerializedName("trafast") val trafast: List<Trafast>
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Section.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Section.kt
@@ -1,0 +1,13 @@
+package com.boostcamp.planj.data.model.naver
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Section(
+    @SerializedName("congestion") val congestion: Int,
+    @SerializedName("distance") val distance: Int,
+    @SerializedName("name") val name: String,
+    @SerializedName("pointCount") val pointCount: Int,
+    @SerializedName("pointIndex") val pointIndex: Int,
+    @SerializedName("speed") val speed: Int
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Start.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Start.kt
@@ -1,0 +1,8 @@
+package com.boostcamp.planj.data.model.naver
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Start(
+    @SerializedName("location") val location: List<Double>
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Summary.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Summary.kt
@@ -1,0 +1,17 @@
+package com.boostcamp.planj.data.model.naver
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Summary(
+    @SerializedName("bbox") val bbox: List<List<Double>>,
+    @SerializedName("departureTime") val departureTime: String,
+    @SerializedName("distance") val distance: Int,
+    @SerializedName("duration") val duration: Int,
+    @SerializedName("etaServiceType") val etaServiceType: Int,
+    @SerializedName("fuelPrice") val fuelPrice: Int,
+    @SerializedName("goal") val goal: Goal,
+    @SerializedName("start") val start: Start,
+    @SerializedName("taxiFare") val taxiFare: Int,
+    @SerializedName("tollFare") val tollFare: Int
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Trafast.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/naver/Trafast.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.planj.data.model.naver
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Trafast(
+    @SerializedName("guide") val guide: List<Guide>,
+    @SerializedName("path") val path: List<List<Double>>,
+    @SerializedName("section") val section: List<Section>,
+    @SerializedName("summary") val summary: Summary
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/LoginApi.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/LoginApi.kt
@@ -1,0 +1,18 @@
+package com.boostcamp.planj.data.network
+
+import com.boostcamp.planj.data.model.LoginResponse
+import com.boostcamp.planj.data.model.SignInRequest
+import com.boostcamp.planj.data.model.SignUpRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface LoginApi {
+
+    @POST("/api/auth/register")
+    suspend fun postSignUp(@Body signUpRequest: SignUpRequest): Response<LoginResponse>
+
+    @POST("/api/auth/login")
+    suspend fun postSignIn(@Body signInRequest: SignInRequest): Response<LoginResponse>
+
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/MainApi.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/MainApi.kt
@@ -2,31 +2,18 @@ package com.boostcamp.planj.data.network
 
 import com.boostcamp.planj.data.model.DeleteCategoryBody
 import com.boostcamp.planj.data.model.DeleteScheduleBody
-import com.boostcamp.planj.data.model.LoginResponse
 import com.boostcamp.planj.data.model.PatchScheduleBody
 import com.boostcamp.planj.data.model.PatchScheduleResponse
 import com.boostcamp.planj.data.model.PostCategoryBody
 import com.boostcamp.planj.data.model.PostCategoryResponse
 import com.boostcamp.planj.data.model.PostScheduleBody
 import com.boostcamp.planj.data.model.PostScheduleResponse
-import com.boostcamp.planj.data.model.SignInRequest
-import com.boostcamp.planj.data.model.SignUpRequest
-import com.boostcamp.planj.data.model.SignUpResult
-import kotlinx.coroutines.flow.Flow
-import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.DELETE
 import retrofit2.http.HTTP
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 
-interface PlanJAPI {
-
-    @POST("/api/auth/register")
-    suspend fun postSignUp(@Body signUpRequest: SignUpRequest): Response<LoginResponse>
-
-    @POST("/api/auth/login")
-    suspend fun postSignIn(@Body signInRequest: SignInRequest): Response<LoginResponse>
+interface MainApi {
 
     @POST("/api/category/add")
     suspend fun postCategory(@Body createCategoryBody : PostCategoryBody) : PostCategoryResponse

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/NaverApi.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/NaverApi.kt
@@ -1,0 +1,15 @@
+package com.boostcamp.planj.data.network
+
+import com.boostcamp.planj.data.model.naver.NaverResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface NaverApi {
+
+    @GET("/map-direction/v1/driving")
+    suspend fun getNaverRoute(
+        @Query("start") start : String,
+        @Query("goal") goal : String,
+        @Query("option") option : String,
+    ) : NaverResponse
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/LoginRepositoryImpl.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/LoginRepositoryImpl.kt
@@ -10,7 +10,7 @@ import com.boostcamp.planj.data.model.LoginResponse
 import com.boostcamp.planj.data.model.SignInRequest
 import com.boostcamp.planj.data.model.SignUpRequest
 import com.boostcamp.planj.data.network.ApiResult
-import com.boostcamp.planj.data.network.PlanJAPI
+import com.boostcamp.planj.data.network.LoginApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
@@ -19,7 +19,7 @@ import java.io.IOException
 import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
-    private val apiService: PlanJAPI,
+    private val apiService: LoginApi,
     private val dataStore : DataStore<Preferences>
 ) : LoginRepository {
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
@@ -31,7 +31,7 @@ interface MainRepository {
 
     suspend fun updateCategory(category: Category)
 
-    fun getWeekSchedule( ): Flow<List<Schedule>>
+    fun getWeekSchedule(): Flow<List<Schedule>>
 
     fun getCategoryTitleSchedule(title: String): Flow<List<Schedule>>
 
@@ -40,25 +40,25 @@ interface MainRepository {
     suspend fun deleteUser(email: String)
 
     fun getAllUser(): Flow<List<User>>
-  
+
     fun searchSchedule(input: String): Flow<List<Schedule>>
-  
-    fun postCategory(postCategoryBody: PostCategoryBody) : Flow<PostCategoryResponse>
 
-    fun postSchedule(userId : String, categoryId : String, title: String ,endTime : String) : Flow<PostScheduleResponse>
-    fun getUser() : Flow<String>
+    fun postCategory(postCategoryBody: PostCategoryBody): Flow<PostCategoryResponse>
 
-    fun getCategory(categoryName : String) : Category
+    fun postSchedule(categoryId: String, title: String, endTime: String): Flow<PostScheduleResponse>
+    fun getUser(): Flow<String>
 
-    suspend fun deleteScheduleApi(userUuid : String, scheduleUuid : String)
+    fun getCategory(categoryName: String): Category
+
+    suspend fun deleteScheduleApi(userUuid: String, scheduleUuid: String)
 
     suspend fun deleteCategoryApi(userUuid: String, scheduleUuid: String)
 
     suspend fun updateSchedule(schedule: Schedule)
 
-    suspend fun updateScheduleUsingCategory(categoryNameBefore : String, categoryAfter : String)
+    suspend fun updateScheduleUsingCategory(categoryNameBefore: String, categoryAfter: String)
 
-    fun patchSchedule(patchScheduleBody: PatchScheduleBody) : Flow<PatchScheduleResponse>
+    fun patchSchedule(patchScheduleBody: PatchScheduleBody): Flow<PatchScheduleResponse>
 
     suspend fun deleteScheduleUsingCategoryName(categoryName: String)
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
@@ -16,7 +16,7 @@ import com.boostcamp.planj.data.model.PostScheduleBody
 import com.boostcamp.planj.data.model.PostScheduleResponse
 import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.data.model.User
-import com.boostcamp.planj.data.network.PlanJAPI
+import com.boostcamp.planj.data.network.MainApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
@@ -25,7 +25,7 @@ import java.io.IOException
 import javax.inject.Inject
 
 class MainRepositoryImpl @Inject constructor(
-    private val api: PlanJAPI,
+    private val api: MainApi,
     private val db: AppDatabase,
     private val dataStore: DataStore<Preferences>
 ) : MainRepository {
@@ -100,12 +100,11 @@ class MainRepositoryImpl @Inject constructor(
         }
 
     override fun postSchedule(
-        userId: String,
         categoryId: String,
         title: String,
         endTime: String
     ): Flow<PostScheduleResponse> = flow {
-        val postSchedule = PostScheduleBody(userId, categoryId, title, endTime)
+        val postSchedule = PostScheduleBody(categoryId, title, endTime)
         emit(api.postSchedule(postSchedule))
     }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/NaverRepository.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/NaverRepository.kt
@@ -1,0 +1,8 @@
+package com.boostcamp.planj.data.repository
+
+import com.boostcamp.planj.data.model.naver.NaverResponse
+import kotlinx.coroutines.flow.Flow
+
+interface NaverRepository {
+    suspend fun getNaverRoute(start : String, goal : String) : NaverResponse
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/NaverRepositoryImpl.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/NaverRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.boostcamp.planj.data.repository
+
+import android.util.Log
+import com.boostcamp.planj.data.model.naver.NaverResponse
+import com.boostcamp.planj.data.network.NaverApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class NaverRepositoryImpl @Inject constructor(
+    private val api: NaverApi
+) : NaverRepository {
+    override suspend fun getNaverRoute(start: String, goal: String): NaverResponse =
+        api.getNaverRoute(start,goal, "trafast")
+
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
@@ -2,20 +2,25 @@ package com.boostcamp.planj.ui
 
 import android.graphics.Color
 import android.graphics.Paint
+import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.appcompat.widget.AppCompatButton
 import androidx.databinding.BindingAdapter
 import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.Alarm
 import com.boostcamp.planj.data.model.Category
 import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.data.model.Schedule
+import com.boostcamp.planj.data.model.naver.NaverResponse
 import com.boostcamp.planj.getDate
 import com.boostcamp.planj.getTime
 import com.boostcamp.planj.ui.login.EmailState
 import com.boostcamp.planj.ui.login.PwdState
+import com.boostcamp.planj.ui.schedule.ScheduleStartMapViewModel
+import com.boostcamp.planj.ui.schedule.ScheduleViewModel
 import com.google.android.material.textfield.TextInputLayout
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -138,5 +143,72 @@ fun TextView.setDateTime(schedule: Schedule) {
         } else {
             "${startDate.replace("-", "/")} - ${endDate.replace("-", "/")}"
         }
+    }
+}
+
+@BindingAdapter("endImageVisible")
+fun ImageView.setImageVisible(viewModel : ScheduleViewModel){
+    if(!viewModel.isEditMode.value) {
+        visibility = View.GONE
+        return
+    }
+
+    visibility =if(viewModel.scheduleLocation.value == null) {
+         View.GONE
+    }else{
+        View.VISIBLE
+    }
+}
+
+@BindingAdapter("startImageVisible")
+fun ImageView.setEndImageVisible(viewModel : ScheduleViewModel){
+    if(!viewModel.isEditMode.value) {
+        visibility = View.GONE
+        return
+    }
+
+    visibility =if(viewModel.startScheduleLocation.value == null) {
+        View.GONE
+    }else{
+        View.VISIBLE
+    }
+}
+
+@BindingAdapter("btnVisible")
+fun TextView.setVisible(viewModel : ScheduleViewModel){
+    visibility =if(viewModel.startScheduleLocation.value == null || viewModel.scheduleLocation.value == null) {
+        View.GONE
+    }else{
+        View.VISIBLE
+    }
+}
+
+@BindingAdapter("setTime")
+fun TextView.setTime(response: NaverResponse?){
+    response?.let {
+        var time = it.route.trafast[0].summary.duration
+        val hour = time/(1000 * 60 * 60)
+        time %= (1000 * 60 * 60)
+        val min = time/(1000 * 60)
+
+        text = if(hour == 0){
+            "소요 시간 ${min}분"
+        } else {
+            "소요 시간 ${hour}시 ${min}분"
+        }
+    }
+}
+
+@BindingAdapter("setDistance")
+fun TextView.setDistance(response: NaverResponse?){
+    response?.let {
+        val distance = it.route.trafast[0].summary.distance
+
+        text = if(distance >= 1000){
+            "거리 : ${distance/1000.0}km"
+        } else {
+            "거리 : ${distance}m "
+        }
+
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
@@ -146,33 +146,6 @@ fun TextView.setDateTime(schedule: Schedule) {
     }
 }
 
-@BindingAdapter("endImageVisible")
-fun ImageView.setImageVisible(viewModel : ScheduleViewModel){
-    if(!viewModel.isEditMode.value) {
-        visibility = View.GONE
-        return
-    }
-
-    visibility =if(viewModel.scheduleLocation.value == null) {
-         View.GONE
-    }else{
-        View.VISIBLE
-    }
-}
-
-@BindingAdapter("startImageVisible")
-fun ImageView.setEndImageVisible(viewModel : ScheduleViewModel){
-    if(!viewModel.isEditMode.value) {
-        visibility = View.GONE
-        return
-    }
-
-    visibility =if(viewModel.startScheduleLocation.value == null) {
-        View.GONE
-    }else{
-        View.VISIBLE
-    }
-}
 
 @BindingAdapter("btnVisible")
 fun TextView.setVisible(viewModel : ScheduleViewModel){

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailViewModel.kt
@@ -47,7 +47,7 @@ class CategoryDetailViewModel @Inject constructor(
     fun insertSchedule(category: String, title: String, endTime: String) {
         viewModelScope.launch(Dispatchers.IO) {
             val getCategory = mainRepository.getCategory(category)
-            mainRepository.postSchedule("01HFYAR1FX09FKQ2SW1HTG8BJ8", getCategory.categoryId, title, endTime)
+            mainRepository.postSchedule(getCategory.categoryId, title, endTime)
                 .catch {
                     Log.d("PLANJDEBUG", "postSchedule error ${it.message}")
                 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/login/SignInViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/login/SignInViewModel.kt
@@ -51,6 +51,8 @@ class SignInViewModel @Inject constructor(
                         else -> _showToast.emit("Error")
                     }
                 }
+
+                else -> {}
             }
         }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/MainViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/MainViewModel.kt
@@ -25,7 +25,7 @@ class MainViewModel @Inject constructor(
     fun insertSchedule(category : String, title : String, endTime : String) {
         viewModelScope.launch(Dispatchers.IO){
             categories.value.find { it.categoryName == category }?.let {c ->
-                mainRepository.postSchedule("01HFYAR1FX09FKQ2SW1HTG8BJ8",c.categoryId, title, endTime)
+                mainRepository.postSchedule(c.categoryId, title, endTime)
                     .catch {
                         Log.d("PLANJDEBUG", "postSchedule error ${it.message}")
                     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryViewModel.kt
@@ -36,12 +36,9 @@ class CategoryViewModel @Inject constructor(
                 .contains(categoryName)) {
             CategoryState.EXIST
         } else {
-            val currentTime = SimpleDateFormat(
-                "yyyy-MM-dd HH:mm:ss",
-                Locale("kr", "ko")
-            ).format(System.currentTimeMillis()).replace(" ", "T").trim()
+
             viewModelScope.launch(Dispatchers.IO) {
-                val categoryBody = PostCategoryBody("01HFYAR1FX09FKQ2SW1HTG8BJ8", categoryName, currentTime)
+                val categoryBody = PostCategoryBody(categoryName)
                 mainRepository.postCategory(categoryBody)
                     .catch {
                         Log.d("PLANJDEBUG", "postCategory Error ${it.message}")

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -65,7 +65,7 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
         binding.viewModel = viewModel
         binding.lifecycleOwner = viewLifecycleOwner
 
-        viewModel.setLocation(args.location)
+        viewModel.setLocation(args.location, args.startLocation)
         binding.executePendingBindings()
 
         initAdapter()

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ArrayAdapter
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -65,6 +66,7 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
         binding.lifecycleOwner = viewLifecycleOwner
 
         viewModel.setLocation(args.location)
+        binding.executePendingBindings()
 
         initAdapter()
         setObserver()
@@ -99,12 +101,14 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.categoryList.collect { categoryList ->
-                (binding.tilScheduleCategory.editText as MaterialAutoCompleteTextView).setText(
-                    categoryList.getOrNull(categoryList.indexOf(viewModel.selectedCategory))
-                )
-                (binding.tilScheduleCategory.editText as MaterialAutoCompleteTextView).setSimpleItems(
-                    categoryList.toTypedArray()
-                )
+//                (binding.tilScheduleCategory.editText as MaterialAutoCompleteTextView).setText(
+//                    categoryList.getOrNull(categoryList.indexOf(viewModel.selectedCategory))
+//                )
+//                (binding.tilScheduleCategory.editText as MaterialAutoCompleteTextView).setSimpleItems(
+//                    categoryList.toTypedArray()
+//                )
+                val arrayAdapter = ArrayAdapter(requireContext(), R.layout.item_dropdown, categoryList)
+                binding.actvScheduleSelectedCategory.setAdapter(arrayAdapter)
             }
         }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -29,7 +29,7 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
     private val binding get() = _binding!!
     private val viewModel: ScheduleViewModel by activityViewModels()
 
-    private val args : ScheduleFragmentArgs by navArgs()
+    private val args: ScheduleFragmentArgs by navArgs()
 
     private val repetitionSettingDialog by lazy {
         RepetitionSettingDialog()
@@ -107,7 +107,8 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
 //                (binding.tilScheduleCategory.editText as MaterialAutoCompleteTextView).setSimpleItems(
 //                    categoryList.toTypedArray()
 //                )
-                val arrayAdapter = ArrayAdapter(requireContext(), R.layout.item_dropdown, categoryList)
+                val arrayAdapter =
+                    ArrayAdapter(requireContext(), R.layout.item_dropdown, categoryList)
                 binding.actvScheduleSelectedCategory.setAdapter(arrayAdapter)
             }
         }
@@ -191,7 +192,7 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
             val bundle = Bundle()
             bundle.putParcelable("repetitionInfo", viewModel.scheduleRepetition.value)
             repetitionSettingDialog.arguments = bundle
-            if(!repetitionSettingDialog.isAdded){
+            if (!repetitionSettingDialog.isAdded) {
                 repetitionSettingDialog.show(childFragmentManager, "반복 설정")
             }
         }
@@ -200,13 +201,23 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
             val bundle = Bundle()
             bundle.putParcelable("alarmInfo", viewModel.scheduleAlarm.value)
             alarmSettingDialog.arguments = bundle
-            if(!alarmSettingDialog.isAdded){
+            if (!alarmSettingDialog.isAdded) {
                 alarmSettingDialog.show(childFragmentManager, "알림 설정")
             }
         }
 
         binding.ivScheduleMap.setOnClickListener {
-            val action = ScheduleFragmentDirections.actionScheduleFragmentToScheduleMapFragment(viewModel.scheduleLocation.value)
+            val action =
+                ScheduleFragmentDirections.actionScheduleFragmentToScheduleMapFragment(viewModel.scheduleLocation.value)
+            findNavController().navigate(action)
+        }
+
+        binding.ivScheduleStartMap.setOnClickListener {
+            val action =
+                ScheduleFragmentDirections.actionScheduleFragmentToScheduleStartMapFragment(
+                    endLocation = viewModel.scheduleLocation.value,
+                    startLocation = viewModel.startScheduleLocation.value
+                )
             findNavController().navigate(action)
         }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
@@ -118,10 +118,11 @@ class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
             adapter.submitList(emptyList())
             binding.tietScheduleMapSearchInput.setText("")
             viewModel.setLocation(null)
+
         }
         binding.btnScheduleMapSelectPlace.setOnClickListener {
             val action =
-                ScheduleMapFragmentDirections.actionScheduleMapFragmentToScheduleFragment(viewModel.location.value)
+                ScheduleMapFragmentDirections.actionScheduleMapFragmentToScheduleFragment(location = viewModel.location.value)
             findNavController().navigate(action)
         }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
@@ -49,6 +49,7 @@ class ScheduleMapViewModel @Inject constructor(
     }
 
 
+
     fun changeClick() {
         _clicked.value = !_clicked.value
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleStartMapFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleStartMapFragment.kt
@@ -7,65 +7,89 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.navigation.NavOptions
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
+import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.Location
-import com.boostcamp.planj.databinding.FragmentScheduleMapBinding
+import com.boostcamp.planj.databinding.FragmentScheduleStartMapBinding
 import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
 import com.naver.maps.map.CameraAnimation
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.MapView
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.OnMapReadyCallback
 import com.naver.maps.map.overlay.Marker
+import com.naver.maps.map.overlay.PathOverlay
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.util.Locale
 
-@AndroidEntryPoint
-class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
 
-    private var _binding: FragmentScheduleMapBinding? = null
+@AndroidEntryPoint
+class ScheduleStartMapFragment : Fragment(), OnMapReadyCallback {
+    private var _binding: FragmentScheduleStartMapBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: ScheduleMapViewModel by viewModels()
-    private val args: ScheduleMapFragmentArgs by navArgs()
+   private val viewModel : ScheduleStartMapViewModel by viewModels()
+    private val args: ScheduleStartMapFragmentArgs by navArgs()
 
     private lateinit var adapter: ScheduleSearchAdapter
     private lateinit var mapView: MapView
     private lateinit var naverMap: NaverMap
-    private val marker = Marker()
+    private val startMarker = Marker()
+    private val endMarker = Marker()
+    private val path = PathOverlay()
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentScheduleMapBinding.inflate(inflater, container, false)
+        _binding = FragmentScheduleStartMapBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewmodel = viewModel
         mapView = binding.fragmentContainMap
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
-        setListener()
-        getFocus()
         initAdapter()
         setObserver()
         mapSearch()
+
+        binding.executePendingBindings()
+
+    }
+
+    private fun initCamera() {
+
+        val latLng = if(args.startLocation == null){
+            LatLng(
+                args.endLocation!!.latitude.toDouble(),
+                args.endLocation!!.longitude.toDouble()
+            )
+        }else {
+            LatLng(
+                args.startLocation!!.latitude.toDouble(),
+                args.startLocation!!.longitude.toDouble()
+            )
+        }
+
+        val camera = CameraUpdate.scrollTo(
+            latLng
+        ).animate(CameraAnimation.Linear)
+        naverMap.moveCamera(camera)
     }
 
     override fun onStart() {
@@ -104,46 +128,30 @@ class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
         mapView.onLowMemory()
     }
 
+
     override fun onMapReady(p0: NaverMap) {
         this.naverMap = p0
         naverMap.setOnMapClickListener { _, latLng ->
             getMarker(latLng)
         }
-        viewModel.initLocation(args.location)
+        getEndMarker(args.endLocation)
+        initCamera()
+        viewModel.initLocation(args.startLocation)
     }
 
-    private fun setListener() {
-        binding.tilScheduleMapSearch.setEndIconOnClickListener {
-            marker.map = null
-            adapter.submitList(emptyList())
-            binding.tietScheduleMapSearchInput.setText("")
-            viewModel.setLocation(null)
-        }
-        binding.btnScheduleMapSelectPlace.setOnClickListener {
-            val action =
-                ScheduleMapFragmentDirections.actionScheduleMapFragmentToScheduleFragment(viewModel.location.value)
-            findNavController().navigate(action)
-        }
+    private fun getEndMarker(endLocation: Location?){
+        endLocation ?: return
+        startMarker.map = null
+        startMarker.position =
+            LatLng(endLocation.latitude.toDouble(), endLocation.longitude.toDouble())
+        startMarker.map = naverMap
     }
 
-    private fun getFocus() {
-        binding.tietScheduleMapSearchInput.requestFocus()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            binding.tietScheduleMapSearchInput.windowInsetsController?.show(
-                WindowInsetsCompat.Type.ime()
-            )
-        } else {
-            activity?.let {
-                WindowInsetsControllerCompat(it.window, binding.tietScheduleMapSearchInput)
-                    .show(WindowInsetsCompat.Type.ime())
-            }
-        }
-    }
 
     private fun getMarker(latLng: LatLng) {
-        marker.map = null
-        marker.position = latLng
-        marker.map = naverMap
+        getEndMarker(args.endLocation)
+        endMarker.position = latLng
+        endMarker.map = naverMap
 
         getAddress(latLng)
     }
@@ -226,24 +234,45 @@ class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.location.collectLatest {
+                viewModel.startLocation.collectLatest {
                     it?.let { location ->
                         if (location.address.isNotEmpty()) {
                             binding.tietScheduleMapSearchInput.setText(location.placeName)
                             binding.tietScheduleMapSearchInput.setSelection(location.placeName.length)
-                            val camera = CameraUpdate.scrollTo(
-                                LatLng(
-                                    location.latitude.toDouble(),
-                                    location.longitude.toDouble()
-                                )
-                            )
-                                .animate(CameraAnimation.Linear)
-                            naverMap.moveCamera(camera)
-                            marker.map = null
-                            marker.position =
+
+                            getEndMarker(args.endLocation)
+
+//                            val start = LatLng(args.endLocation!!.latitude.toDouble() , args.endLocation!!.longitude.toDouble())
+//                            val end = LatLng(viewModel.startLocation.value!!.latitude.toDouble(), viewModel.startLocation.value!!.longitude.toDouble())
+//                            val bounds = LatLngBounds(start, end)
+//                            val camera = CameraUpdate.fitBounds(bounds, 300).animate(CameraAnimation.Linear)
+//                            naverMap.moveCamera(camera)
+
+                            endMarker.position =
                                 LatLng(it.latitude.toDouble(), it.longitude.toDouble())
-                            marker.map = naverMap
+                            endMarker.map = naverMap
+                            viewModel.getNaverRoute(it, args.endLocation!!)
                         }
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.route.collectLatest {
+                    it?.let{ response ->
+                        val latLngList = response.route.trafast[0].path.map { position -> LatLng(position[1], position[0]) }
+                        path.map = null
+                        path.coords = latLngList
+                        path.color = resources.getColor(R.color.red, null)
+                        path.map = naverMap
+
+                        val start = LatLng(args.endLocation!!.latitude.toDouble() , args.endLocation!!.longitude.toDouble())
+                        val end = LatLng(viewModel.startLocation.value!!.latitude.toDouble(), viewModel.startLocation.value!!.longitude.toDouble())
+                        val bounds = LatLngBounds(start, end)
+                        val camera = CameraUpdate.fitBounds(bounds, 300).animate(CameraAnimation.Linear)
+                        naverMap.moveCamera(camera)
                     }
                 }
             }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleStartMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleStartMapViewModel.kt
@@ -5,28 +5,35 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boostcamp.planj.data.model.Address
 import com.boostcamp.planj.data.model.Location
+import com.boostcamp.planj.data.model.naver.NaverResponse
+import com.boostcamp.planj.data.repository.NaverRepository
 import com.boostcamp.planj.data.repository.SearchRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import java.lang.Exception
 import javax.inject.Inject
 
 @HiltViewModel
-class ScheduleMapViewModel @Inject constructor(
+class ScheduleStartMapViewModel @Inject constructor(
+    private val naverRepository: NaverRepository,
     private val searchRepository: SearchRepository
 ) : ViewModel() {
 
-    private val _location = MutableStateFlow<Location?>(null)
-    val location: StateFlow<Location?> = _location.asStateFlow()
+    private val _startLocation = MutableStateFlow<Location?>(null)
+    val startLocation: StateFlow<Location?> = _startLocation.asStateFlow()
+
 
     private val _clicked = MutableStateFlow(false)
     val clicked: StateFlow<Boolean> = _clicked.asStateFlow()
 
     private val _searchMap = MutableStateFlow<List<Address>>(emptyList())
     val searchMap: StateFlow<List<Address>> = _searchMap.asStateFlow()
+
+    private val _route = MutableStateFlow<NaverResponse?>(null)
+    val route: StateFlow<NaverResponse?> = _route.asStateFlow()
 
     fun searchMap(query: String) {
         viewModelScope.launch {
@@ -38,18 +45,32 @@ class ScheduleMapViewModel @Inject constructor(
         }
     }
 
-    fun initLocation(location: Location?){
-        _location.value = location
+    fun initLocation(startLocation: Location?) {
+        _startLocation.value = startLocation
         _clicked.value = true
     }
 
 
     fun setLocation(location: Location?) {
-        _location.value = location
+        _startLocation.value = location
     }
 
 
     fun changeClick() {
         _clicked.value = !_clicked.value
+    }
+
+    fun getNaverRoute(startLocation: Location?, endLocation: Location) {
+        if (startLocation == null) return
+
+        val start = "${startLocation.longitude},${startLocation.latitude}"
+        val end = "${endLocation.longitude},${endLocation.latitude}"
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                _route.value = naverRepository.getNaverRoute(start, end)
+            }catch (e : Exception){
+                Log.d("PLANJDEBUG", "error ${e.message}")
+            }
+        }
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleStartMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleStartMapViewModel.kt
@@ -55,6 +55,9 @@ class ScheduleStartMapViewModel @Inject constructor(
         _startLocation.value = location
     }
 
+    fun emptyRoute(){
+        _route.value = null
+    }
 
     fun changeClick() {
         _clicked.value = !_clicked.value

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -137,8 +137,9 @@ class ScheduleViewModel @Inject constructor(
         _scheduleAlarm.value = alarm
     }
 
-    fun setLocation(location: Location?) {
+    fun setLocation(location: Location?, startLocation: Location?) {
         scheduleLocation.value = location
+        startScheduleLocation.value = startLocation
     }
 
     fun startEditingSchedule() {
@@ -213,5 +214,13 @@ class ScheduleViewModel @Inject constructor(
     fun resetStartTime() {
         _scheduleStartDate.value = null
         _scheduleStartTime.value = null
+    }
+
+    fun endMapDelete(){
+        scheduleLocation.value = null
+    }
+
+    fun startMapDelete(){
+        startScheduleLocation.value = null
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -62,6 +62,8 @@ class ScheduleViewModel @Inject constructor(
     val scheduleLocation = MutableStateFlow<Location?>(null)
     val scheduleMemo = MutableStateFlow<String?>(null)
 
+    val startScheduleLocation = MutableStateFlow<Location?>(null)
+
     private val dateFormat = SimpleDateFormat("yyyy/MM/dd")
 
     val categoryList: StateFlow<List<String>> =

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -499,7 +499,8 @@
                     app:layout_constraintBottom_toBottomOf="@id/tv_schedule_location"
                     app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"
                     app:layout_constraintTop_toTopOf="@id/tv_schedule_location"
-                    app:endImageVisible="@{viewModel}"
+                    android:visibility="@{viewModel.isEditMode() == false ? View.GONE : View.VISIBLE}"
+                    android:onClick="@{() -> viewModel.endMapDelete()}"
                     />
 
 
@@ -569,7 +570,8 @@
                             android:contentDescription="@string/location"
                             android:padding="8dp"
                             android:src="@drawable/ic_delete"
-                            app:startImageVisible="@{viewModel}"
+                            android:visibility="@{viewModel.isEditMode() == false ? View.GONE : View.VISIBLE}"
+                            android:onClick="@{() -> viewModel.startMapDelete()}"
                             />
 
 

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -91,7 +91,7 @@
                         android:inputType="none"
                         android:maxLines="1"
                         android:paddingHorizontal="24dp"
-                        android:text="@={viewModel.scheduleCategory}"
+                        android:text="@{viewModel.scheduleCategory}"
                         android:textColor="@color/selector_text_color"
                         android:textSize="14sp" />
                 </com.google.android.material.textfield.TextInputLayout>
@@ -272,7 +272,7 @@
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/layout_schedule_participants"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="350dp"
                     android:maxHeight="150dp"
                     android:paddingHorizontal="24dp"
                     android:paddingVertical="8dp"
@@ -315,10 +315,11 @@
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/rv_schedule_participants"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
+                        android:layout_height="100dp"
                         android:layout_marginTop="8dp"
                         android:nestedScrollingEnabled="false"
                         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                        app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/tv_category_participants"
@@ -402,20 +403,73 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition" />
 
+                <androidx.constraintlayout.widget.Guideline
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_schedule_location"
+                    app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
+
+
+                <TextView
+                    android:id="@+id/tv_schedule_location_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="60dp"
+                    android:text="위치"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="24sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition" />
+
+                <TextView
+                    android:id="@+id/tv_schedule_location_url_scheme"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:gravity="center_vertical"
+                    android:text="다른 경로 보기"
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintBottom_toTopOf="@+id/et_schedule_location_setting"
+                    app:layout_constraintEnd_toStartOf="@id/tv_schedule_location_alarm"
+                    android:padding="8dp"
+                    android:layout_marginVertical="4dp"
+                    android:layout_marginHorizontal="8dp"
+                    android:background="@drawable/round_r8_main2"
+                    />
+
+                <TextView
+                    android:id="@+id/tv_schedule_location_alarm"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:gravity="center_vertical"
+                    android:text="위치 알림 설정"
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintBottom_toTopOf="@+id/et_schedule_location_setting"
+                    android:padding="8dp"
+                    android:layout_marginHorizontal="8dp"
+                    android:layout_marginVertical="4dp"
+                    android:background="@drawable/round_r8_main2"
+                    />
+
+
                 <TextView
                     android:id="@+id/tv_schedule_location"
-                    android:layout_width="160dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="60dp"
                     android:gravity="center_vertical"
                     android:maxLines="1"
                     android:paddingHorizontal="24dp"
+                    android:layout_marginStart="8dp"
                     android:text="@string/location"
-                    android:textSize="16sp"
+                    android:textSize="12sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location_title" />
 
-                <EditText
+                <TextView
                     android:id="@+id/et_schedule_location_setting"
                     android:layout_width="0dp"
                     android:layout_height="60dp"
@@ -424,33 +478,126 @@
                     android:gravity="center_vertical"
                     android:importantForAutofill="no"
                     android:inputType="text"
-                    android:maxLines="1"
                     android:paddingHorizontal="24dp"
                     android:text="@{viewModel.scheduleLocation.placeName}"
                     android:textColor="@color/selector_text_color"
-                    android:textSize="16sp"
-                    app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"
+                    android:textSize="12sp"
+                    android:breakStrategy="simple"
+                    app:layout_constraintEnd_toStartOf="@id/iv_schedule_end_map_delete"
                     app:layout_constraintStart_toEndOf="@id/tv_schedule_location"
-                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location_title" />
+
+                <ImageView
+                    android:id="@+id/iv_schedule_end_map_delete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="60dp"
+                    android:clickable="@{viewModel.isEditMode()}"
+                    android:contentDescription="@string/location"
+                    android:padding="8dp"
+                    android:src="@drawable/ic_delete"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_schedule_location"
+                    app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"
+                    app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
+
+
 
                 <ImageView
                     android:id="@+id/iv_schedule_map"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_height="0dp"
+                    android:clickable="@{viewModel.isEditMode()}"
                     android:contentDescription="@string/location"
-                    android:padding="24dp"
+                    android:padding="18dp"
                     android:src="@drawable/ic_location"
                     app:layout_constraintBottom_toBottomOf="@id/tv_schedule_location"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/et_schedule_location_setting"
                     app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
+
+
+                <LinearLayout
+                    android:id="@+id/layout_schedule_end_map"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location"
+                    android:visibility="@{viewModel.scheduleLocation == null ? View.GONE : View.VISIBLE}"
+                    >
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="60dp"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="60dp"
+                            android:gravity="center_vertical"
+                            android:paddingHorizontal="24dp"
+                            android:text="출발"
+                            android:textSize="12dp"
+                            android:layout_marginStart="8dp"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/et_schedule_start_location_setting"
+                            android:layout_width="0dp"
+                            android:layout_height="60dp"
+                            android:layout_weight="9"
+                            android:background="@null"
+                            android:enabled="@{viewModel.isEditMode}"
+                            android:gravity="center_vertical"
+                            android:importantForAutofill="no"
+                            android:inputType="text"
+                            android:paddingHorizontal="24dp"
+                            android:breakStrategy="simple"
+                            android:text="@{viewModel.scheduleLocation.placeName}"
+                            android:textColor="@color/selector_text_color"
+                            android:textSize="12sp"
+                            app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"
+                            app:layout_constraintStart_toEndOf="@id/tv_schedule_location"
+                            app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition" />
+
+                        <ImageView
+                            android:id="@+id/iv_schedule_start_map_delete"
+                            android:layout_width="wrap_content"
+                            android:layout_height="60dp"
+                            android:clickable="@{viewModel.isEditMode()}"
+                            android:contentDescription="@string/location"
+                            android:padding="8dp"
+                            android:src="@drawable/ic_delete"
+                            />
+
+
+                        <ImageView
+                            android:id="@+id/iv_schedule_start_map"
+                            android:layout_width="wrap_content"
+                            android:layout_height="60dp"
+                            android:clickable="@{viewModel.isEditMode()}"
+                            android:contentDescription="@string/location"
+                            android:padding="18dp"
+                            android:src="@drawable/ic_location"
+                             />
+
+                    </LinearLayout>
+
+                    <com.naver.maps.map.MapView
+                        android:id="@+id/fragment_contain_map"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dp"
+                        android:touchscreenBlocksFocus="true" />
+
+                </LinearLayout>
+
 
                 <com.google.android.material.divider.MaterialDivider
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_schedule_end_map" />
+
 
                 <TextView
                     android:id="@+id/tv_schedule_memo"
@@ -464,7 +611,7 @@
                     android:textSize="16sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_schedule_end_map" />
 
                 <TextView
                     android:id="@+id/tv_schedule_memo_length"
@@ -476,7 +623,7 @@
                     android:text="@string/memo_length"
                     android:textSize="16sp"
                     app:layout_constraintStart_toEndOf="@id/tv_schedule_memo"
-                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_schedule_end_map" />
 
                 <EditText
                     android:layout_width="0dp"

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -437,6 +437,7 @@
                     android:layout_marginVertical="4dp"
                     android:layout_marginHorizontal="8dp"
                     android:background="@drawable/round_r8_main2"
+                    app:btnVisible="@{viewModel}"
                     />
 
                 <TextView
@@ -452,6 +453,7 @@
                     android:layout_marginHorizontal="8dp"
                     android:layout_marginVertical="4dp"
                     android:background="@drawable/round_r8_main2"
+                    app:btnVisible="@{viewModel}"
                     />
 
 
@@ -474,7 +476,6 @@
                     android:layout_width="0dp"
                     android:layout_height="60dp"
                     android:background="@null"
-                    android:enabled="@{viewModel.isEditMode}"
                     android:gravity="center_vertical"
                     android:importantForAutofill="no"
                     android:inputType="text"
@@ -497,7 +498,9 @@
                     android:src="@drawable/ic_delete"
                     app:layout_constraintBottom_toBottomOf="@id/tv_schedule_location"
                     app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"
-                    app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
+                    app:layout_constraintTop_toTopOf="@id/tv_schedule_location"
+                    app:endImageVisible="@{viewModel}"
+                    />
 
 
 
@@ -546,13 +549,12 @@
                             android:layout_height="60dp"
                             android:layout_weight="9"
                             android:background="@null"
-                            android:enabled="@{viewModel.isEditMode}"
                             android:gravity="center_vertical"
                             android:importantForAutofill="no"
                             android:inputType="text"
                             android:paddingHorizontal="24dp"
                             android:breakStrategy="simple"
-                            android:text="@{viewModel.scheduleLocation.placeName}"
+                            android:text="@{viewModel.startScheduleLocation.placeName}"
                             android:textColor="@color/selector_text_color"
                             android:textSize="12sp"
                             app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"
@@ -567,6 +569,7 @@
                             android:contentDescription="@string/location"
                             android:padding="8dp"
                             android:src="@drawable/ic_delete"
+                            app:startImageVisible="@{viewModel}"
                             />
 
 

--- a/PlanJ/app/src/main/res/layout/fragment_schedule_start_map.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule_start_map.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <import type="android.view.View"/>
+
+        <variable
+            name="viewmodel"
+            type="com.boostcamp.planj.ui.schedule.ScheduleStartMapViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_schedule_map_search"
+            style="@style/ThemeOverlay.Material3.TextInputEditText.FilledBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:elevation="1dp"
+            app:boxBackgroundColor="@color/main2"
+            app:endIconMode="clear_text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:startIconDrawable="@drawable/ic_search">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/tiet_schedule_map_search_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionDone"
+                android:inputType="text"
+                android:maxLines="1" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <FrameLayout
+            android:id="@+id/layout_search_drop_down"
+            android:layout_width="0dp"
+            android:layout_height="250dp"
+            android:elevation="1dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/til_schedule_map_search">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_schedule_map_search_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:background="@drawable/round_search_background"
+                android:scrollbars="vertical"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/til_schedule_map_search" />
+
+        </FrameLayout>
+
+
+        <FrameLayout
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.naver.maps.map.MapView
+                android:id="@+id/fragment_contain_map"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:touchscreenBlocksFocus="true" />
+        </FrameLayout>
+
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_schedule_map_select_place"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginBottom="16dp"
+            android:background="@drawable/round_r8_main1"
+            android:elevation="1dp"
+            android:padding="16dp"
+            android:text="위치 등록하기"
+            android:textColor="@color/main2"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:id="@+id/btn_schedule_map_start_time"
+            android:layout_width="150dp"
+            android:layout_height="50dp"
+            android:background="@drawable/round_r8_main2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/btn_schedule_map_select_place"
+            android:layout_marginStart="16dp"
+            android:layout_marginBottom="8dp"
+            android:visibility="@{viewmodel.route == null ? View.GONE : View.VISIBLE}"
+            android:elevation="1dp"
+            app:setTime="@{viewmodel.route}"
+            android:textColor="@color/main3"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            android:gravity="center"
+            />
+
+        <TextView
+            android:id="@+id/btn_schedule_map_start_distance"
+            android:layout_width="150dp"
+            android:layout_height="50dp"
+            app:layout_constraintStart_toEndOf="@id/btn_schedule_map_start_time"
+            app:layout_constraintBottom_toTopOf="@id/btn_schedule_map_select_place"
+            android:layout_marginStart="8dp"
+            android:layout_marginBottom="8dp"
+            android:background="@drawable/round_r8_main2"
+            android:visibility="@{viewmodel.route == null ? View.GONE : View.VISIBLE}"
+            android:elevation="1dp"
+            android:gravity="center"
+            android:textColor="@color/main3"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            app:setDistance="@{viewmodel.route}"
+            />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/PlanJ/app/src/main/res/navigation/schedule_nav.xml
+++ b/PlanJ/app/src/main/res/navigation/schedule_nav.xml
@@ -30,6 +30,9 @@
             app:argType="com.boostcamp.planj.data.model.Location"
             app:nullable="true"
             android:defaultValue="@null" />
+        <action
+            android:id="@+id/action_scheduleFragment_to_scheduleStartMapFragment"
+            app:destination="@id/scheduleStartMapFragment" />
     </fragment>
     <fragment
         android:id="@+id/scheduleMapFragment"
@@ -43,6 +46,21 @@
             app:destination="@id/scheduleFragment" />
         <argument
             android:name="location"
+            app:argType="com.boostcamp.planj.data.model.Location"
+            app:nullable="true"
+            android:defaultValue="@null" />
+    </fragment>
+    <fragment
+        android:id="@+id/scheduleStartMapFragment"
+        android:name="com.boostcamp.planj.ui.schedule.ScheduleStartMapFragment"
+        android:label="ScheduleStartMapFragment" >
+        <argument
+            android:name="endLocation"
+            app:argType="com.boostcamp.planj.data.model.Location"
+            app:nullable="true"
+            android:defaultValue="@null" />
+        <argument
+            android:name="startLocation"
             app:argType="com.boostcamp.planj.data.model.Location"
             app:nullable="true"
             android:defaultValue="@null" />

--- a/PlanJ/app/src/main/res/navigation/schedule_nav.xml
+++ b/PlanJ/app/src/main/res/navigation/schedule_nav.xml
@@ -33,6 +33,11 @@
         <action
             android:id="@+id/action_scheduleFragment_to_scheduleStartMapFragment"
             app:destination="@id/scheduleStartMapFragment" />
+        <argument
+            android:name="startLocation"
+            app:argType="com.boostcamp.planj.data.model.Location"
+            app:nullable="true"
+            android:defaultValue="@null" />
     </fragment>
     <fragment
         android:id="@+id/scheduleMapFragment"
@@ -64,5 +69,8 @@
             app:argType="com.boostcamp.planj.data.model.Location"
             app:nullable="true"
             android:defaultValue="@null" />
+        <action
+            android:id="@+id/action_scheduleStartMapFragment_to_scheduleFragment"
+            app:destination="@id/scheduleFragment" />
     </fragment>
 </navigation>

--- a/PlanJ/app/src/main/res/values/strings.xml
+++ b/PlanJ/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="end">종료</string>
     <string name="alarm">알림</string>
     <string name="repetition">반복</string>
-    <string name="location">위치</string>
+    <string name="location">도착</string>
     <string name="memo">추가 메모</string>
     <string name="category">카테고리</string>
     <string name="memo_length">%d/255</string>


### PR DESCRIPTION
# 로그인 메인 모듈 분리
+ 로그인, 메인 모듈 합칠 시 데이터 스토어에 있던 유저 정보를 가져오지 못하는 오류가 발생
+ 이를 해결하기위해 로그인 모듈 따로, 메인 화면에서 시작할 때 실행하는 메인 모듈을 따로 만들어 사용

# 도착 위치 지도 구현
+ 도착 위치기 있을 경우에 출발 위치를 선택할 수 있는 화면과 지도가 보여진다.
+ 출발 위치의 주소 아이콘을 누를 때 출발 위치를 선택할 수 있는 화면으로 이동한다.
+ 출발 지점을 클릭 시 도착 지점과 길찾기를 naver Directions5를 이용하여 가장 빠른 길찾기 1개를 가져와 화면에 표시한다.