### PR TITLE
[K026] 네이버 지도 연동, 일정화면에서 지도 보이게 설정, 알림 설정 및 다른 대중교통(url scheme 적용)

### DIFF
--- a/PlanJ/app/src/main/AndroidManifest.xml
+++ b/PlanJ/app/src/main/AndroidManifest.xml
@@ -23,14 +23,22 @@
             android:exported="false" />
         <activity
             android:name=".ui.schedule.ScheduleActivity"
-            android:exported="false"
+            android:exported="true"
             android:windowSoftInputMode="adjustResize"
-            />
+            >
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.APP_BROWSER"/>
+            </intent-filter>
+
+        </activity>
         <activity
             android:name=".ui.login.LoginActivity"
             android:exported="true"
             android:windowSoftInputMode="adjustPan"
             >
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -41,7 +49,6 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true">
-
 
         </activity>
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostScheduleBody.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostScheduleBody.kt
@@ -1,9 +1,22 @@
 package com.boostcamp.planj.data.model
 
+import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
 
 data class PostScheduleBody(
     @SerializedName("categoryUuid") val categoryUuid : String,
     @SerializedName("title") val title : String,
-    @SerializedName("endAt") val endAt : String
+    @SerializedName("endAt") val endAt : String,
+    @SerializedName("startLocation") val startLocation: TempLocation= TempLocation(),
+    @SerializedName("endLocation") val endLocation : TempLocation=TempLocation()
 )
+
+@Parcelize
+data class TempLocation(
+    val placeName : String="",
+    val address : String="",
+    val latitude : Double=23.123,
+    val longitude : Double=23.123
+) : Parcelable
+

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostScheduleBody.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/PostScheduleBody.kt
@@ -8,15 +8,6 @@ data class PostScheduleBody(
     @SerializedName("categoryUuid") val categoryUuid : String,
     @SerializedName("title") val title : String,
     @SerializedName("endAt") val endAt : String,
-    @SerializedName("startLocation") val startLocation: TempLocation= TempLocation(),
-    @SerializedName("endLocation") val endLocation : TempLocation=TempLocation()
 )
 
-@Parcelize
-data class TempLocation(
-    val placeName : String="",
-    val address : String="",
-    val latitude : Double=23.123,
-    val longitude : Double=23.123
-) : Parcelable
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
@@ -2,12 +2,10 @@ package com.boostcamp.planj.ui
 
 import android.graphics.Color
 import android.graphics.Paint
-import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.appcompat.widget.AppCompatButton
 import androidx.databinding.BindingAdapter
 import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.Alarm
@@ -19,7 +17,6 @@ import com.boostcamp.planj.getDate
 import com.boostcamp.planj.getTime
 import com.boostcamp.planj.ui.login.EmailState
 import com.boostcamp.planj.ui.login.PwdState
-import com.boostcamp.planj.ui.schedule.ScheduleStartMapViewModel
 import com.boostcamp.planj.ui.schedule.ScheduleViewModel
 import com.google.android.material.textfield.TextInputLayout
 import java.text.SimpleDateFormat
@@ -149,7 +146,7 @@ fun TextView.setDateTime(schedule: Schedule) {
 
 @BindingAdapter("btnVisible")
 fun TextView.setVisible(viewModel : ScheduleViewModel){
-    visibility =if(viewModel.startScheduleLocation.value == null || viewModel.scheduleLocation.value == null) {
+    visibility =if(viewModel.startScheduleLocation.value == null || viewModel.endScheduleLocation.value == null) {
         View.GONE
     }else{
         View.VISIBLE

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
@@ -58,9 +58,9 @@ fun TextView.setRepetitionInfo(repetition: Repetition?) {
 
 @BindingAdapter("alarmInfo")
 fun TextView.setAlarmInfo(alarmInfo: Alarm?) {
-    text = if (alarmInfo != null && alarmInfo.alarmType == "departure") {
+    text = if (alarmInfo != null && alarmInfo.alarmType == "DEPARTURE") {
         resources.getString(R.string.before_departure_time, alarmInfo.alarmTime)
-    } else if (alarmInfo != null && alarmInfo.alarmType == "end") {
+    } else if (alarmInfo != null && alarmInfo.alarmType == "END") {
         resources.getString(R.string.before_end_time, alarmInfo.alarmTime)
     } else {
         resources.getString(R.string.not_set)
@@ -143,15 +143,6 @@ fun TextView.setDateTime(schedule: Schedule) {
     }
 }
 
-
-@BindingAdapter("btnVisible")
-fun TextView.setVisible(viewModel : ScheduleViewModel){
-    visibility =if(viewModel.startScheduleLocation.value == null || viewModel.endScheduleLocation.value == null) {
-        View.GONE
-    }else{
-        View.VISIBLE
-    }
-}
 
 @BindingAdapter("setTime")
 fun TextView.setTime(response: NaverResponse?){

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/MainActivity.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/MainActivity.kt
@@ -1,5 +1,8 @@
 package com.boostcamp.planj.ui.main
 
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -44,6 +47,7 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+
     }
 
     private fun setListener() {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/week/adapter/CalendarViewHolder.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/week/adapter/CalendarViewHolder.kt
@@ -26,7 +26,7 @@ class CalendarViewHolder(private val binding: ItemWeekDayBinding) :
         binding.tvWeekDayWeek.text = scheduleList.calendar.dayOfWeek
         val today = scheduleList.calendar.dayNumber
 
-        binding.layoutWeekDay.setOnClickListener {
+        binding.layoutClick.setOnClickListener {
 
             val layoutInflater = LayoutInflater.from(context)
             val view = layoutInflater.inflate(R.layout.dialog_schedule_result, null)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleActivity.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleActivity.kt
@@ -1,5 +1,8 @@
 package com.boostcamp.planj.ui.schedule
 
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -18,5 +21,6 @@ class ScheduleActivity : AppCompatActivity() {
         setContentView(R.layout.activity_schedule)
 
         viewModel.setScheduleInfo(args.schedule)
+
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleBottomSheetDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleBottomSheetDialog.kt
@@ -10,8 +10,9 @@ import android.widget.Toast
 import com.boostcamp.planj.databinding.ScheduleBottomSheetBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class ScheduleBottomSheetDialog() : BottomSheetDialogFragment() {
-    private var _binding : ScheduleBottomSheetBinding? = null
+class ScheduleBottomSheetDialog(private val time: Int, private val onClick: (Int) -> Unit) :
+    BottomSheetDialogFragment() {
+    private var _binding: ScheduleBottomSheetBinding? = null
     private val binding get() = _binding!!
 
 
@@ -31,8 +32,19 @@ class ScheduleBottomSheetDialog() : BottomSheetDialogFragment() {
         binding.npScheduleBottom.maxValue = 60
         binding.npScheduleBottom.value = 30
 
+        var mTime = time
+        val hour = mTime / (1000 * 60 * 60)
+        mTime %= (1000 * 60 * 60)
+        val min = mTime / (1000 * 60)
+
+        binding.tvScheduleBottomExpectTime.text = if (hour == 0) {
+            "소요 시간 ${min}분"
+        } else {
+            "소요 시간 ${hour}시 ${min}분"
+        }
+
         binding.btnScheduleBottom.setOnClickListener {
-            Toast.makeText(requireContext(), "버튼 클릭", Toast.LENGTH_SHORT).show()
+            onClick(binding.npScheduleBottom.value)
             dismiss()
         }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleBottomSheetDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleBottomSheetDialog.kt
@@ -1,0 +1,44 @@
+package com.boostcamp.planj.ui.schedule
+
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import com.boostcamp.planj.databinding.ScheduleBottomSheetBinding
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class ScheduleBottomSheetDialog() : BottomSheetDialogFragment() {
+    private var _binding : ScheduleBottomSheetBinding? = null
+    private val binding get() = _binding!!
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = ScheduleBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.npScheduleBottom.minValue = 0
+        binding.npScheduleBottom.maxValue = 60
+        binding.npScheduleBottom.value = 30
+
+        binding.btnScheduleBottom.setOnClickListener {
+            Toast.makeText(requireContext(), "버튼 클릭", Toast.LENGTH_SHORT).show()
+            dismiss()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.withContext
 
 
 @AndroidEntryPoint
-class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSettingDialogListener{
+class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSettingDialogListener {
 
     private var _binding: FragmentScheduleBinding? = null
     private val binding get() = _binding!!
@@ -114,18 +114,20 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.isEditMode.collect { isEditMode ->
                 updateToolbar(isEditMode)
-                if(isEditMode) {
-                    binding.ivScheduleStartMapDelete.visibility =  if(viewModel.startScheduleLocation.value == null){
-                        View.GONE
-                    }else{
-                        View.VISIBLE
-                    }
+                if (isEditMode) {
+                    binding.ivScheduleStartMapDelete.visibility =
+                        if (viewModel.startScheduleLocation.value == null) {
+                            View.GONE
+                        } else {
+                            View.VISIBLE
+                        }
 
-                    binding.ivScheduleEndMapDelete.visibility =  if(viewModel.endScheduleLocation.value == null){
-                        View.GONE
-                    }else{
-                        View.VISIBLE
-                    }
+                    binding.ivScheduleEndMapDelete.visibility =
+                        if (viewModel.endScheduleLocation.value == null) {
+                            View.GONE
+                        } else {
+                            View.VISIBLE
+                        }
 
                 }
             }
@@ -152,16 +154,16 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED){
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.scheduleAlarm.collect { alarm ->
-                    if(alarm == null){
+
+                    if (alarm != null && alarm.alarmType == "DEPARTURE") {
+                        binding.tvScheduleLocationAlarm.text = "위치 알람 해제"
+                        binding.tvScheduleLocationAlarm.setBackgroundResource(R.drawable.round_r8_red)
+
+                    } else {
                         binding.tvScheduleLocationAlarm.text = "위치 알람 설정"
                         binding.tvScheduleLocationAlarm.setBackgroundResource(R.drawable.round_r8_main2)
-                    }else{
-                        if(alarm.alarmType == "DEPARTURE"){
-                            binding.tvScheduleLocationAlarm.text = "위치 알람 해제"
-                            binding.tvScheduleLocationAlarm.setBackgroundResource(R.drawable.round_r8_red)
-                        }
                     }
                 }
             }
@@ -317,12 +319,13 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
 
         binding.tvScheduleLocationAlarm.setOnClickListener {
             viewModel.route.value?.let {
-                if(binding.tvScheduleLocationAlarm.text == "위치 알람 해제"){
+                if (binding.tvScheduleLocationAlarm.text == "위치 알람 해제") {
                     viewModel.setAlarm(null)
-                }else{
-                    val bottomSheet = ScheduleBottomSheetDialog(it.route.trafast[0].summary.duration){min ->
-                        viewModel.setAlarm(Alarm("DEPARTURE", min))
-                    }
+                } else {
+                    val bottomSheet =
+                        ScheduleBottomSheetDialog(it.route.trafast[0].summary.duration) { min ->
+                            viewModel.setAlarm(Alarm("DEPARTURE", min))
+                        }
                     bottomSheet.show(childFragmentManager, tag)
                 }
             }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -114,6 +114,20 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.isEditMode.collect { isEditMode ->
                 updateToolbar(isEditMode)
+                if(isEditMode) {
+                    binding.ivScheduleStartMapDelete.visibility =  if(viewModel.startScheduleLocation.value == null){
+                        View.GONE
+                    }else{
+                        View.VISIBLE
+                    }
+
+                    binding.ivScheduleEndMapDelete.visibility =  if(viewModel.endScheduleLocation.value == null){
+                        View.GONE
+                    }else{
+                        View.VISIBLE
+                    }
+
+                }
             }
         }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -2,6 +2,7 @@ package com.boostcamp.planj.ui.schedule
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
@@ -133,6 +134,22 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
                 val arrayAdapter =
                     ArrayAdapter(requireContext(), R.layout.item_dropdown, categoryList)
                 binding.actvScheduleSelectedCategory.setAdapter(arrayAdapter)
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED){
+                viewModel.scheduleAlarm.collect { alarm ->
+                    if(alarm == null){
+                        binding.tvScheduleLocationAlarm.text = "위치 알람 설정"
+                        binding.tvScheduleLocationAlarm.setBackgroundResource(R.drawable.round_r8_main2)
+                    }else{
+                        if(alarm.alarmType == "DEPARTURE"){
+                            binding.tvScheduleLocationAlarm.text = "위치 알람 해제"
+                            binding.tvScheduleLocationAlarm.setBackgroundResource(R.drawable.round_r8_red)
+                        }
+                    }
+                }
             }
         }
 
@@ -286,11 +303,14 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
 
         binding.tvScheduleLocationAlarm.setOnClickListener {
             viewModel.route.value?.let {
-                val bottomSheet = ScheduleBottomSheetDialog(it.route.trafast[0].summary.duration){min ->
-                    viewModel.setAlarm(Alarm("DEPARTURE", min))
+                if(binding.tvScheduleLocationAlarm.text == "위치 알람 해제"){
+                    viewModel.setAlarm(null)
+                }else{
+                    val bottomSheet = ScheduleBottomSheetDialog(it.route.trafast[0].summary.duration){min ->
+                        viewModel.setAlarm(Alarm("DEPARTURE", min))
+                    }
+                    bottomSheet.show(childFragmentManager, tag)
                 }
-                bottomSheet.show(childFragmentManager, tag)
-
             }
         }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
@@ -38,7 +38,7 @@ class ScheduleMapViewModel @Inject constructor(
         }
     }
 
-    fun initLocation(location: Location?){
+    fun initLocation(location: Location?) {
         _location.value = location
         _clicked.value = true
     }
@@ -47,7 +47,6 @@ class ScheduleMapViewModel @Inject constructor(
     fun setLocation(location: Location?) {
         _location.value = location
     }
-
 
 
     fun changeClick() {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleShowMapFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleShowMapFragment.kt
@@ -1,0 +1,192 @@
+package com.boostcamp.planj.ui.schedule
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.boostcamp.planj.R
+import com.boostcamp.planj.databinding.FragmentShowMapBinding
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
+import com.naver.maps.map.CameraAnimation
+import com.naver.maps.map.CameraUpdate
+import com.naver.maps.map.MapView
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.OnMapReadyCallback
+import com.naver.maps.map.overlay.Marker
+import com.naver.maps.map.overlay.PathOverlay
+import kotlinx.coroutines.launch
+
+class ScheduleShowMapFragment : Fragment(), OnMapReadyCallback {
+
+    private var _binding: FragmentShowMapBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ScheduleViewModel by activityViewModels()
+
+    private lateinit var mapView: MapView
+    private lateinit var naverMap: NaverMap
+    private val startMarker = Marker()
+    private val endMarker = Marker()
+    private val path = PathOverlay()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentShowMapBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        mapView = binding.fragmentContainMap
+        mapView.onCreate(savedInstanceState)
+        mapView.getMapAsync(this)
+        startMarker.width = 70
+        startMarker.height = 100
+        endMarker.width = 70
+        endMarker.height = 100
+
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView.onStop()
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+        mapView.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
+
+    override fun onMapReady(p0: NaverMap) {
+        this.naverMap = p0
+        naverMap.uiSettings.isZoomGesturesEnabled = false
+        naverMap.uiSettings.isLogoClickEnabled = false
+        naverMap.uiSettings.isScrollGesturesEnabled = false
+        naverMap.uiSettings.isZoomControlEnabled = false
+        naverMap.uiSettings.isScaleBarEnabled = false
+        setObserver()
+    }
+
+    private fun setObserver() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.endScheduleLocation.collect { el ->
+                    Log.d("PLANJDEBUG", "${el}")
+                    if (el != null) {
+                        val latLng = LatLng(el.latitude.toDouble(), el.longitude.toDouble())
+                        endMarker.position = latLng
+                        endMarker.map = naverMap
+
+                        val camera = CameraUpdate.scrollTo(latLng)
+                            .animate(CameraAnimation.Linear)
+                        naverMap.moveCamera(camera)
+                    } else {
+                        endMarker.map = null
+                        viewModel.emptyStartLocation()
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.startScheduleLocation.collect { sl ->
+                    if (sl != null) {
+                        val endLocation = viewModel.endScheduleLocation.value
+                        if (endLocation != null) {
+                            val latLng = LatLng(sl.latitude.toDouble(), sl.longitude.toDouble())
+                            startMarker.position = latLng
+                            startMarker.map = naverMap
+                            viewModel.getNaverRoute(sl, endLocation)
+                        }
+                    } else {
+                        startMarker.map = null
+                        viewModel.emptyRoute()
+                        if(endMarker.map != null){
+                            viewModel.endScheduleLocation.value?.let {el ->
+                                val latLng = LatLng(el.latitude.toDouble(), el.longitude.toDouble())
+                                val camera = CameraUpdate.scrollTo(latLng)
+                                    .animate(CameraAnimation.Linear)
+                                naverMap.moveCamera(camera)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.route.collect { route ->
+                    route?.let { response ->
+                        val latLngList = response.route.trafast[0].path.map { position ->
+                            LatLng(
+                                position[1],
+                                position[0]
+                            )
+                        }
+                        path.map = null
+                        path.coords = latLngList
+                        path.color = resources.getColor(R.color.red, null)
+                        path.map = naverMap
+
+                        val start = LatLng(
+                            viewModel.endScheduleLocation.value!!.latitude.toDouble(),
+                            viewModel.endScheduleLocation.value!!.longitude.toDouble()
+                        )
+                        val end = LatLng(
+                            viewModel.startScheduleLocation.value!!.latitude.toDouble(),
+                            viewModel.startScheduleLocation.value!!.longitude.toDouble()
+                        )
+                        val bounds = LatLngBounds(start, end)
+                        val camera =
+                            CameraUpdate.fitBounds(bounds, 150).animate(CameraAnimation.Linear)
+                        naverMap.moveCamera(camera)
+                    }
+                    if(route == null) {
+                        path.map = null
+                    }
+                }
+            }
+
+
+        }
+    }
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleShowMapFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleShowMapFragment.kt
@@ -138,8 +138,8 @@ class ScheduleShowMapFragment : Fragment(), OnMapReadyCallback {
                     } else {
                         startMarker.map = null
                         viewModel.emptyRoute()
-                        if(endMarker.map != null){
-                            viewModel.endScheduleLocation.value?.let {el ->
+                        if (endMarker.map != null) {
+                            viewModel.endScheduleLocation.value?.let { el ->
                                 val latLng = LatLng(el.latitude.toDouble(), el.longitude.toDouble())
                                 val camera = CameraUpdate.scrollTo(latLng)
                                     .animate(CameraAnimation.Linear)
@@ -180,7 +180,7 @@ class ScheduleShowMapFragment : Fragment(), OnMapReadyCallback {
                             CameraUpdate.fitBounds(bounds, 150).animate(CameraAnimation.Linear)
                         naverMap.moveCamera(camera)
                     }
-                    if(route == null) {
+                    if (route == null) {
                         path.map = null
                     }
                 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleStartMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleStartMapViewModel.kt
@@ -55,7 +55,7 @@ class ScheduleStartMapViewModel @Inject constructor(
         _startLocation.value = location
     }
 
-    fun emptyRoute(){
+    fun emptyRoute() {
         _route.value = null
     }
 
@@ -71,7 +71,7 @@ class ScheduleStartMapViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 _route.value = naverRepository.getNaverRoute(start, end)
-            }catch (e : Exception){
+            } catch (e: Exception) {
                 Log.d("PLANJDEBUG", "error ${e.message}")
             }
         }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -60,7 +61,8 @@ class ScheduleViewModel @Inject constructor(
     private val _scheduleRepetition = MutableStateFlow<Repetition?>(null)
     val scheduleRepetition: StateFlow<Repetition?> = _scheduleRepetition
 
-    val scheduleLocation = MutableStateFlow<Location?>(null)
+    private val _endScheduleLocation = MutableStateFlow<Location?>(null)
+    val endScheduleLocation = _endScheduleLocation.asStateFlow()
     val scheduleMemo = MutableStateFlow<String?>(null)
 
     val startScheduleLocation = MutableStateFlow<Location?>(null)
@@ -100,7 +102,7 @@ class ScheduleViewModel @Inject constructor(
             _scheduleAlarm.value = schedule.alarm
             _doneMembers.value = schedule.doneMembers
             //_members.value = schedule.members
-            scheduleLocation.value = schedule.location
+            _endScheduleLocation.value = schedule.location
             isFinished.value = schedule.isFinished
             isFailed.value = schedule.isFailed
         }
@@ -138,8 +140,9 @@ class ScheduleViewModel @Inject constructor(
         _scheduleAlarm.value = alarm
     }
 
-    fun setLocation(location: Location?, startLocation: Location?) {
-        scheduleLocation.value = location
+    fun setLocation(startLocation: Location?, endLocation: Location?) {
+        Log.d("PLANJDEBUG", "setLocation ${endLocation}")
+        _endScheduleLocation.value = endLocation
         startScheduleLocation.value = startLocation
     }
 
@@ -175,10 +178,10 @@ class ScheduleViewModel @Inject constructor(
                 scheduleEndDate.value?.let {
                     "${it.replace("/", "-")}T${scheduleEndTime.value}:00"
                 }?: "",
-                scheduleLocation.value?.placeName ?: "" ,
-                scheduleLocation.value?.address ?: "",
-                scheduleLocation.value?.latitude ?: "",
-                scheduleLocation.value?.longitude ?: ""
+                _endScheduleLocation.value?.placeName ?: "" ,
+                _endScheduleLocation.value?.address ?: "",
+                _endScheduleLocation.value?.latitude ?: "",
+                _endScheduleLocation.value?.longitude ?: ""
             )
 
             mainRepository.patchSchedule(patchScheduleBody)
@@ -201,7 +204,7 @@ class ScheduleViewModel @Inject constructor(
                         alarm = scheduleAlarm.value,
                         members = emptyList(),
                         doneMembers = doneMembers.value,
-                        location = scheduleLocation.value,
+                        location = _endScheduleLocation.value,
                         isFinished = isFinished.value,
                         isFailed = isFailed.value
                     )
@@ -219,7 +222,7 @@ class ScheduleViewModel @Inject constructor(
     }
 
     fun endMapDelete(){
-        scheduleLocation.value = null
+        _endScheduleLocation.value = null
     }
 
     fun startMapDelete(){

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -179,11 +179,11 @@ class ScheduleViewModel @Inject constructor(
                 scheduleMemo.value ?: "",
                 scheduleStartDate.value?.let {
                     "${it.replace("/", "-")}T${scheduleStartTime.value}:00"
-                }?: "",
+                } ?: "",
                 scheduleEndDate.value?.let {
                     "${it.replace("/", "-")}T${scheduleEndTime.value}:00"
-                }?: "",
-                _endScheduleLocation.value?.placeName ?: "" ,
+                } ?: "",
+                _endScheduleLocation.value?.placeName ?: "",
                 _endScheduleLocation.value?.address ?: "",
                 _endScheduleLocation.value?.latitude ?: "",
                 _endScheduleLocation.value?.longitude ?: ""
@@ -201,9 +201,19 @@ class ScheduleViewModel @Inject constructor(
                         startTime = if (scheduleStartDate.value == null) {
                             null
                         } else {
-                            "${scheduleStartDate.value?.replace('/', '-')}T${scheduleStartTime.value}:00"
+                            "${
+                                scheduleStartDate.value?.replace(
+                                    '/',
+                                    '-'
+                                )
+                            }T${scheduleStartTime.value}:00"
                         },
-                        endTime = "${scheduleEndDate.value?.replace('/', '-')}T${scheduleEndTime.value}:00",
+                        endTime = "${
+                            scheduleEndDate.value?.replace(
+                                '/',
+                                '-'
+                            )
+                        }T${scheduleEndTime.value}:00",
                         categoryTitle = scheduleCategory.value,
                         repetition = scheduleRepetition.value,
                         alarm = scheduleAlarm.value,
@@ -226,11 +236,11 @@ class ScheduleViewModel @Inject constructor(
         _scheduleStartTime.value = null
     }
 
-    fun endMapDelete(){
+    fun endMapDelete() {
         _endScheduleLocation.value = null
     }
 
-    fun startMapDelete(){
+    fun startMapDelete() {
         startScheduleLocation.value = null
     }
 
@@ -243,17 +253,17 @@ class ScheduleViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 _route.value = naverRepository.getNaverRoute(start, end)
-            }catch (e : Exception){
+            } catch (e: Exception) {
                 Log.d("PLANJDEBUG", "error ${e.message}")
             }
         }
     }
 
-    fun emptyRoute(){
+    fun emptyRoute() {
         _route.value = null
     }
 
-    fun emptyStartLocation(){
+    fun emptyStartLocation() {
         startScheduleLocation.value = null
     }
 }

--- a/PlanJ/app/src/main/res/drawable/round_r8_red.xml
+++ b/PlanJ/app/src/main/res/drawable/round_r8_red.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="8dp"/>
+    <solid android:color="@color/red"/>
+</shape>

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -586,7 +586,7 @@
 
 
                     <androidx.fragment.app.FragmentContainerView
-                        android:id="@+id/schedule_map_nav_host_fragment"
+                        android:id="@+id/fragment_container_show_map"
                         android:name="androidx.navigation.fragment.NavHostFragment"
                         app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view"
                         android:layout_width="match_parent"

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -411,7 +411,6 @@
                     app:layout_constraintBottom_toBottomOf="@id/tv_schedule_location"
                     app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
 
-
                 <TextView
                     android:id="@+id/tv_schedule_location_title"
                     android:layout_width="wrap_content"
@@ -501,7 +500,6 @@
                     app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"
                     app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
 
-
                 <ImageView
                     android:id="@+id/iv_schedule_map"
                     android:layout_width="wrap_content"
@@ -513,7 +511,6 @@
                     app:layout_constraintBottom_toBottomOf="@id/tv_schedule_location"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
-
 
                 <LinearLayout
                     android:id="@+id/layout_schedule_start_view"
@@ -569,7 +566,6 @@
                             android:src="@drawable/ic_delete"
                             android:visibility="@{viewModel.startScheduleLocation == null ? View.GONE : View.VISIBLE}" />
 
-
                         <ImageView
                             android:id="@+id/iv_schedule_start_map"
                             android:layout_width="wrap_content"
@@ -580,7 +576,6 @@
                             android:src="@drawable/ic_location" />
 
                     </LinearLayout>
-
 
                     <androidx.fragment.app.FragmentContainerView
                         android:id="@+id/fragment_container_show_map"
@@ -599,7 +594,6 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view" />
-
 
                 <TextView
                     android:id="@+id/tv_schedule_memo"
@@ -647,18 +641,6 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>
-
-
-        <FrameLayout
-            android:id="@+id/standard_bottom_sheet"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
-            app:layout_constraintBottom_toBottomOf="parent">
-
-            <!-- Bottom sheet contents. -->
-
-        </FrameLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -434,7 +434,7 @@
                     android:gravity="center_vertical"
                     android:padding="8dp"
                     android:text="다른 경로 보기"
-                    app:btnVisible="@{viewModel}"
+                    android:visibility="@{viewModel.startScheduleLocation == null ? View.GONE : View.VISIBLE}"
                     app:layout_constraintBottom_toTopOf="@+id/et_schedule_location_setting"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintEnd_toStartOf="@id/tv_schedule_location_alarm"
@@ -450,7 +450,7 @@
                     android:gravity="center_vertical"
                     android:padding="8dp"
                     android:text="위치 알림 설정"
-                    app:btnVisible="@{viewModel}"
+                    android:visibility="@{viewModel.startScheduleLocation == null ? View.GONE : View.VISIBLE}"
                     app:layout_constraintBottom_toTopOf="@+id/et_schedule_location_setting"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition" />
@@ -516,15 +516,21 @@
 
 
 
+                <LinearLayout
+                    android:id="@+id/layout_schedule_start_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="@{viewModel.endScheduleLocation == null ? View.GONE : View.VISIBLE}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location"
+                    android:orientation="vertical"
+                    >
+
                     <LinearLayout
-                        android:id="@+id/layout_schedule_start_view"
                         android:layout_width="match_parent"
                         android:layout_height="60dp"
                         android:orientation="horizontal"
-                        android:visibility="@{viewModel.endScheduleLocation == null ? View.GONE : View.VISIBLE}"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/tv_schedule_location"
                         >
 
                         <TextView
@@ -578,21 +584,24 @@
 
                     </LinearLayout>
 
-                    <com.naver.maps.map.MapView
-                        android:id="@+id/fragment_contain_map"
+
+                    <androidx.fragment.app.FragmentContainerView
+                        android:id="@+id/schedule_map_nav_host_fragment"
+                        android:name="androidx.navigation.fragment.NavHostFragment"
+                        app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view"
                         android:layout_width="match_parent"
                         android:layout_height="200dp"
-                        app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view"
-                        />
+                        app:defaultNavHost="true"
+                        app:navGraph="@navigation/map_show_nav" />
 
-
+                </LinearLayout>
 
                 <com.google.android.material.divider.MaterialDivider
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/fragment_contain_map" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view" />
 
 
                 <TextView
@@ -607,7 +616,7 @@
                     android:textSize="16sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/fragment_contain_map" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view" />
 
                 <TextView
                     android:id="@+id/tv_schedule_memo_length"
@@ -619,7 +628,7 @@
                     android:text="@string/memo_length"
                     android:textSize="16sp"
                     app:layout_constraintStart_toEndOf="@id/tv_schedule_memo"
-                    app:layout_constraintTop_toBottomOf="@id/fragment_contain_map" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view" />
 
                 <EditText
                     android:layout_width="0dp"

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -515,23 +515,20 @@
                     app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
 
 
-
                 <LinearLayout
                     android:id="@+id/layout_schedule_start_view"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:orientation="vertical"
                     android:visibility="@{viewModel.endScheduleLocation == null ? View.GONE : View.VISIBLE}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location"
-                    android:orientation="vertical"
-                    >
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location">
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="60dp"
-                        android:orientation="horizontal"
-                        >
+                        android:orientation="horizontal">
 
                         <TextView
                             android:layout_width="wrap_content"
@@ -570,7 +567,7 @@
                             android:onClick="@{() -> viewModel.startMapDelete()}"
                             android:padding="8dp"
                             android:src="@drawable/ic_delete"
-                            android:visibility="@{viewModel.startScheduleLocation == null ? View.GONE : View.VISIBLE}"/>
+                            android:visibility="@{viewModel.startScheduleLocation == null ? View.GONE : View.VISIBLE}" />
 
 
                         <ImageView
@@ -588,10 +585,10 @@
                     <androidx.fragment.app.FragmentContainerView
                         android:id="@+id/fragment_container_show_map"
                         android:name="androidx.navigation.fragment.NavHostFragment"
-                        app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view"
                         android:layout_width="match_parent"
                         android:layout_height="200dp"
                         app:defaultNavHost="true"
+                        app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view"
                         app:navGraph="@navigation/map_show_nav" />
 
                 </LinearLayout>
@@ -656,8 +653,8 @@
             android:id="@+id/standard_bottom_sheet"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+            app:layout_constraintBottom_toBottomOf="parent">
 
             <!-- Bottom sheet contents. -->
 

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -496,7 +496,7 @@
                     android:onClick="@{() -> viewModel.endMapDelete()}"
                     android:padding="8dp"
                     android:src="@drawable/ic_delete"
-                    android:visibility="@{viewModel.isEditMode() == false ? View.GONE : View.VISIBLE}"
+                    android:visibility="@{viewModel.endScheduleLocation == null ? View.GONE : View.VISIBLE}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_schedule_location"
                     app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"
                     app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
@@ -570,7 +570,7 @@
                             android:onClick="@{() -> viewModel.startMapDelete()}"
                             android:padding="8dp"
                             android:src="@drawable/ic_delete"
-                            android:visibility="@{viewModel.isEditMode() == false ? View.GONE : View.VISIBLE}" />
+                            android:visibility="@{viewModel.startScheduleLocation == null ? View.GONE : View.VISIBLE}"/>
 
 
                         <ImageView

--- a/PlanJ/app/src/main/res/layout/fragment_schedule.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_schedule.xml
@@ -416,11 +416,11 @@
                     android:id="@+id/tv_schedule_location_title"
                     android:layout_width="wrap_content"
                     android:layout_height="60dp"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="24sp"
                     android:text="위치"
                     android:textSize="16sp"
                     android:textStyle="bold"
-                    android:gravity="center_vertical"
-                    android:paddingHorizontal="24sp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition" />
 
@@ -428,44 +428,42 @@
                     android:id="@+id/tv_schedule_location_url_scheme"
                     android:layout_width="wrap_content"
                     android:layout_height="0dp"
-                    android:gravity="center_vertical"
-                    android:text="다른 경로 보기"
-                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintBottom_toTopOf="@+id/et_schedule_location_setting"
-                    app:layout_constraintEnd_toStartOf="@id/tv_schedule_location_alarm"
-                    android:padding="8dp"
-                    android:layout_marginVertical="4dp"
                     android:layout_marginHorizontal="8dp"
+                    android:layout_marginVertical="4dp"
                     android:background="@drawable/round_r8_main2"
+                    android:gravity="center_vertical"
+                    android:padding="8dp"
+                    android:text="다른 경로 보기"
                     app:btnVisible="@{viewModel}"
-                    />
+                    app:layout_constraintBottom_toTopOf="@+id/et_schedule_location_setting"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/tv_schedule_location_alarm"
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition" />
 
                 <TextView
                     android:id="@+id/tv_schedule_location_alarm"
                     android:layout_width="wrap_content"
                     android:layout_height="0dp"
-                    android:gravity="center_vertical"
-                    android:text="위치 알림 설정"
-                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintBottom_toTopOf="@+id/et_schedule_location_setting"
-                    android:padding="8dp"
                     android:layout_marginHorizontal="8dp"
                     android:layout_marginVertical="4dp"
                     android:background="@drawable/round_r8_main2"
+                    android:gravity="center_vertical"
+                    android:padding="8dp"
+                    android:text="위치 알림 설정"
                     app:btnVisible="@{viewModel}"
-                    />
+                    app:layout_constraintBottom_toTopOf="@+id/et_schedule_location_setting"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_repetition" />
 
 
                 <TextView
                     android:id="@+id/tv_schedule_location"
                     android:layout_width="wrap_content"
                     android:layout_height="60dp"
+                    android:layout_marginStart="8dp"
                     android:gravity="center_vertical"
                     android:maxLines="1"
                     android:paddingHorizontal="24dp"
-                    android:layout_marginStart="8dp"
                     android:text="@string/location"
                     android:textSize="12sp"
                     android:textStyle="bold"
@@ -477,14 +475,14 @@
                     android:layout_width="0dp"
                     android:layout_height="60dp"
                     android:background="@null"
+                    android:breakStrategy="simple"
                     android:gravity="center_vertical"
                     android:importantForAutofill="no"
                     android:inputType="text"
                     android:paddingHorizontal="24dp"
-                    android:text="@{viewModel.scheduleLocation.placeName}"
+                    android:text="@{viewModel.endScheduleLocation.placeName}"
                     android:textColor="@color/selector_text_color"
                     android:textSize="12sp"
-                    android:breakStrategy="simple"
                     app:layout_constraintEnd_toStartOf="@id/iv_schedule_end_map_delete"
                     app:layout_constraintStart_toEndOf="@id/tv_schedule_location"
                     app:layout_constraintTop_toBottomOf="@id/tv_schedule_location_title" />
@@ -495,15 +493,13 @@
                     android:layout_height="60dp"
                     android:clickable="@{viewModel.isEditMode()}"
                     android:contentDescription="@string/location"
+                    android:onClick="@{() -> viewModel.endMapDelete()}"
                     android:padding="8dp"
                     android:src="@drawable/ic_delete"
+                    android:visibility="@{viewModel.isEditMode() == false ? View.GONE : View.VISIBLE}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_schedule_location"
                     app:layout_constraintEnd_toStartOf="@id/iv_schedule_map"
-                    app:layout_constraintTop_toTopOf="@id/tv_schedule_location"
-                    android:visibility="@{viewModel.isEditMode() == false ? View.GONE : View.VISIBLE}"
-                    android:onClick="@{() -> viewModel.endMapDelete()}"
-                    />
-
+                    app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
 
 
                 <ImageView
@@ -519,30 +515,26 @@
                     app:layout_constraintTop_toTopOf="@id/tv_schedule_location" />
 
 
-                <LinearLayout
-                    android:id="@+id/layout_schedule_end_map"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_schedule_location"
-                    android:visibility="@{viewModel.scheduleLocation == null ? View.GONE : View.VISIBLE}"
-                    >
 
                     <LinearLayout
+                        android:id="@+id/layout_schedule_start_view"
                         android:layout_width="match_parent"
                         android:layout_height="60dp"
-                        android:orientation="horizontal">
+                        android:orientation="horizontal"
+                        android:visibility="@{viewModel.endScheduleLocation == null ? View.GONE : View.VISIBLE}"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_schedule_location"
+                        >
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="60dp"
+                            android:layout_marginStart="8dp"
                             android:gravity="center_vertical"
                             android:paddingHorizontal="24dp"
                             android:text="출발"
                             android:textSize="12dp"
-                            android:layout_marginStart="8dp"
                             android:textStyle="bold" />
 
                         <TextView
@@ -551,11 +543,11 @@
                             android:layout_height="60dp"
                             android:layout_weight="9"
                             android:background="@null"
+                            android:breakStrategy="simple"
                             android:gravity="center_vertical"
                             android:importantForAutofill="no"
                             android:inputType="text"
                             android:paddingHorizontal="24dp"
-                            android:breakStrategy="simple"
                             android:text="@{viewModel.startScheduleLocation.placeName}"
                             android:textColor="@color/selector_text_color"
                             android:textSize="12sp"
@@ -569,11 +561,10 @@
                             android:layout_height="60dp"
                             android:clickable="@{viewModel.isEditMode()}"
                             android:contentDescription="@string/location"
+                            android:onClick="@{() -> viewModel.startMapDelete()}"
                             android:padding="8dp"
                             android:src="@drawable/ic_delete"
-                            android:visibility="@{viewModel.isEditMode() == false ? View.GONE : View.VISIBLE}"
-                            android:onClick="@{() -> viewModel.startMapDelete()}"
-                            />
+                            android:visibility="@{viewModel.isEditMode() == false ? View.GONE : View.VISIBLE}" />
 
 
                         <ImageView
@@ -583,8 +574,7 @@
                             android:clickable="@{viewModel.isEditMode()}"
                             android:contentDescription="@string/location"
                             android:padding="18dp"
-                            android:src="@drawable/ic_location"
-                             />
+                            android:src="@drawable/ic_location" />
 
                     </LinearLayout>
 
@@ -592,9 +582,9 @@
                         android:id="@+id/fragment_contain_map"
                         android:layout_width="match_parent"
                         android:layout_height="200dp"
-                        android:touchscreenBlocksFocus="true" />
+                        app:layout_constraintTop_toBottomOf="@id/layout_schedule_start_view"
+                        />
 
-                </LinearLayout>
 
 
                 <com.google.android.material.divider.MaterialDivider
@@ -602,7 +592,7 @@
                     android:layout_height="wrap_content"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/layout_schedule_end_map" />
+                    app:layout_constraintTop_toBottomOf="@id/fragment_contain_map" />
 
 
                 <TextView
@@ -617,7 +607,7 @@
                     android:textSize="16sp"
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/layout_schedule_end_map" />
+                    app:layout_constraintTop_toBottomOf="@id/fragment_contain_map" />
 
                 <TextView
                     android:id="@+id/tv_schedule_memo_length"
@@ -629,7 +619,7 @@
                     android:text="@string/memo_length"
                     android:textSize="16sp"
                     app:layout_constraintStart_toEndOf="@id/tv_schedule_memo"
-                    app:layout_constraintTop_toBottomOf="@id/layout_schedule_end_map" />
+                    app:layout_constraintTop_toBottomOf="@id/fragment_contain_map" />
 
                 <EditText
                     android:layout_width="0dp"
@@ -651,6 +641,18 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>
+
+
+        <FrameLayout
+            android:id="@+id/standard_bottom_sheet"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+            <!-- Bottom sheet contents. -->
+
+        </FrameLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/PlanJ/app/src/main/res/layout/fragment_show_map.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_show_map.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.naver.maps.map.MapView
+        android:id="@+id/fragment_contain_map"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:touchscreenBlocksFocus="true" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/PlanJ/app/src/main/res/layout/fragment_show_map.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_show_map.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
     <com.naver.maps.map.MapView
         android:id="@+id/fragment_contain_map"

--- a/PlanJ/app/src/main/res/layout/item_week_day.xml
+++ b/PlanJ/app/src/main/res/layout/item_week_day.xml
@@ -6,6 +6,14 @@
     android:clickable="true"
     android:focusable="true">
 
+    <FrameLayout
+        android:id="@+id/layout_click"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/transparent"
+        android:elevation="1dp"
+        />
+
     <LinearLayout
         android:id="@+id/layout_week_day"
         android:layout_width="match_parent"

--- a/PlanJ/app/src/main/res/layout/schedule_bottom_sheet.xml
+++ b/PlanJ/app/src/main/res/layout/schedule_bottom_sheet.xml
@@ -1,85 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/tv_schedule_bottom_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="24sp"
+        android:layout_margin="16dp"
         android:text="알림 설정"
+        android:textSize="24sp"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:layout_margin="16dp"
-        />
+        app:layout_constraintTop_toTopOf="parent" />
 
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_schedule_bottom"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:layout_margin="16dp"
         android:background="@drawable/round_r8_main2"
         android:text="설정하기"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/tv_schedule_bottom_end_title"
-        />
+        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title" />
 
     <TextView
         android:id="@+id/tv_schedule_bottom_departure_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_margin="8dp"
         android:text="출발"
         android:textSize="24sp"
         android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title"
         app:layout_constraintBottom_toBottomOf="parent"
-        android:layout_margin="8dp"
-        />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title" />
 
 
     <TextView
         android:id="@+id/tv_schedule_bottom_expect_time"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_margin="16dp"
         android:textSize="16sp"
         android:textStyle="bold"
-        app:layout_constraintTop_toTopOf="@id/tv_schedule_bottom_title"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="@id/tv_schedule_bottom_title"
-        android:layout_margin="16dp"
-        />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_schedule_bottom_title" />
 
 
     <NumberPicker
         android:id="@+id/np_schedule_bottom"
-        android:layout_width="100dp"
         style="@style/numberPickerCustomSize"
+        android:layout_width="100dp"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toEndOf="@id/tv_schedule_bottom_departure_title"
-        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:layout_marginStart="8dp"
-        />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tv_schedule_bottom_departure_title"
+        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title" />
 
     <TextView
         android:id="@+id/tv_schedule_bottom_end_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
         android:text="분 전 알림"
-        app:layout_constraintStart_toEndOf="@id/np_schedule_bottom"
-        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:textSize="24sp"
         android:textStyle="bold"
-        android:layout_marginStart="8dp"
-        />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/np_schedule_bottom"
+        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/PlanJ/app/src/main/res/layout/schedule_bottom_sheet.xml
+++ b/PlanJ/app/src/main/res/layout/schedule_bottom_sheet.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <TextView
+        android:id="@+id/tv_schedule_bottom_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="24sp"
+        android:text="알림 설정"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_margin="16dp"
+        />
+
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_schedule_bottom"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_margin="16dp"
+        android:background="@drawable/round_r8_main2"
+        android:text="설정하기"
+        app:layout_constraintStart_toEndOf="@id/tv_schedule_bottom_end_title"
+        />
+
+    <TextView
+        android:id="@+id/tv_schedule_bottom_departure_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="출발"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_margin="8dp"
+        />
+
+
+    <TextView
+        android:id="@+id/tv_schedule_bottom_expect_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:hint="소요 시간 : 20 분"
+        app:layout_constraintTop_toTopOf="@id/tv_schedule_bottom_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/tv_schedule_bottom_title"
+        android:layout_margin="16dp"
+        />
+
+
+    <NumberPicker
+        android:id="@+id/np_schedule_bottom"
+        android:layout_width="100dp"
+        style="@style/numberPickerCustomSize"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toEndOf="@id/tv_schedule_bottom_departure_title"
+        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="8dp"
+        />
+
+    <TextView
+        android:id="@+id/tv_schedule_bottom_end_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="분 전 알림"
+        app:layout_constraintStart_toEndOf="@id/np_schedule_bottom"
+        app:layout_constraintTop_toBottomOf="@id/tv_schedule_bottom_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_marginStart="8dp"
+        />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/PlanJ/app/src/main/res/layout/schedule_bottom_sheet.xml
+++ b/PlanJ/app/src/main/res/layout/schedule_bottom_sheet.xml
@@ -50,7 +50,6 @@
         android:layout_height="wrap_content"
         android:textSize="16sp"
         android:textStyle="bold"
-        android:hint="소요 시간 : 20 분"
         app:layout_constraintTop_toTopOf="@id/tv_schedule_bottom_title"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="@id/tv_schedule_bottom_title"

--- a/PlanJ/app/src/main/res/navigation/map_show_nav.xml
+++ b/PlanJ/app/src/main/res/navigation/map_show_nav.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_show_nav"
+    app:startDestination="@id/scheduleShowMapFragment">
+
+    <fragment
+        android:id="@+id/scheduleShowMapFragment"
+        android:name="com.boostcamp.planj.ui.schedule.ScheduleShowMapFragment"
+        android:label="ScheduleShowMapFragment" />
+</navigation>

--- a/PlanJ/app/src/main/res/values/themes.xml
+++ b/PlanJ/app/src/main/res/values/themes.xml
@@ -11,4 +11,11 @@
     <style name="dialog" parent="Theme.AppCompat.Dialog">
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
+
+
+    <style name="numberPickerCustomSize">    <!--Display textSize-->
+        <item name="android:textSize">50sp</item>    <!--Display textColor-->
+        <item name="android:editTextColor">@color/main2</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
 - [X] 지도 ui 알림 수정 화면에서도 보이도록 구현
 - [X] 다른 대중교통 길찾기를 url Scheme으로 볼 수 있게 구현
 - [X] 따로 알림 설정 버튼이 있으며 누를 시 바텀 시트가 나오도록 구현
 
+ 일정 화면에 지도 보이게 구현
    + 도착 지점만 있는경우 해당 위치 마커만 표시
    + 시작과 도착시간이 있는 경우 두 마커와 경로를 표시
    + 다시 시작이 사라지면 도착 지점으로 카메라 이동 구현
    + 일정에 있는 지도는 터치, 기타 기능 동작을 불가능하도록 구현

+ 일정 화면(ScheduleFragment)에 지도를 사용하면 코드가 너무 길어지고, 충돌이 일어나 구현하기 어려움을 느낌
    + 이에 nav_graph를 따로 하나 만들어서 거기에 프래그먼트를 하나 생성해 그 쪽에 지도를 구현하는 방식으로 진행

<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/6464a775-41cc-400e-bc9f-29fbd3378097" width=300 height=600/>

<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/69d7b43f-64d3-4ecc-9bf0-dde6ab84a313" width=300 height=600/>

<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/193fc486-739f-4762-96ce-8bb50ae079da" width=300 height=600/>


---

+ 지도 위치 알람 버튼 설정
    + 텍스트로 입력 받는 것보다 numberPicker가 있어 이를 활용하여 알림을 설정하도록 구현
    + 바텀 시트로 나타나며 옆에는 경로의 소요시간과 알림 설정 버튼이 있다.
    + 알림 설정 버튼을 누르면 일정에 있는 알림의 값이 변경되는 것을 볼 수 있다.
    + 영어를 전부 대문자로 변경 (DEPARTURE, END)

~~아직 구현이 안됐지만 알림 설정버튼을 해서 설정을 하게 된다면, 알림 설정 해제 버튼으로 변경하도록 구현할 예정~~ -> 구현
 
<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/2bcd9679-412d-4904-be6e-ed9e89163679" width=300 height=600/>

<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/ed03ba9d-bf0f-4444-b1c6-4ec9a5cbb8b6" width=300 height=600/>

<img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/56026214/9cb916d0-c10b-4d97-a435-09a6cb01921b" width=300 height=600/>




