### PR TITLE
[J161] 친구 추가 api 입력 형식 변경, 일정 초대 기능 구현

### DIFF
--- a/be/src/friend/dto/add-friend.dto.ts
+++ b/be/src/friend/dto/add-friend.dto.ts
@@ -1,11 +1,7 @@
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsEmail, IsNotEmpty } from "class-validator";
 
 export class AddFriendDto {
-  @IsString()
+  @IsEmail()
   @IsNotEmpty()
-  from: string;
-
-  @IsString()
-  @IsNotEmpty()
-  to: string;
+  friendEmail: string;
 }

--- a/be/src/friend/friend.service.ts
+++ b/be/src/friend/friend.service.ts
@@ -16,12 +16,8 @@ export class FriendService {
   async add(token: string, dto: AddFriendDto): Promise<string> {
     const userUuid = this.authService.verify(token);
 
-    if (userUuid !== dto.from) {
-      throw new BadRequestException();
-    }
-
-    const from = await this.userService.getUserEntity(dto.from);
-    const to = await this.userService.getUserEntity(dto.to);
+    const from = await this.userService.getUserEntity(userUuid);
+    const to = await this.userService.getUserEntityByEmail(dto.friendEmail);
 
     try {
       await this.friendRepository.add(from, to);

--- a/be/src/schedule-api/schedule-api.controller.ts
+++ b/be/src/schedule-api/schedule-api.controller.ts
@@ -41,10 +41,4 @@ export class ScheduleApiController {
     const result = await this.scheduleApiService.deleteSchedule(token, dto);
     return JSON.parse(result);
   }
-
-  @Post("/invite")
-  async inviteSchedule(@Token() token: string, @Body() dto: InviteScheduleDto) {
-    const result = await this.scheduleApiService.inviteSchedule(token, dto);
-    // return JSON.parse(result);
-  }
 }

--- a/be/src/schedule-api/schedule-api.controller.ts
+++ b/be/src/schedule-api/schedule-api.controller.ts
@@ -5,6 +5,7 @@ import { UpdateScheduleDto } from "src/schedule/dto/update-schedule.dto";
 import { DeleteScheduleDto } from "src/schedule/dto/delete-schedule.dto";
 import { Token } from "../utils/token.decorator";
 import { AuthGuard } from "../guard/auth.guard";
+import { InviteScheduleDto } from "src/schedule/dto/invite-schedule.dto";
 
 @Controller("/api/schedule")
 @UseGuards(AuthGuard)
@@ -41,8 +42,9 @@ export class ScheduleApiController {
     return JSON.parse(result);
   }
 
-  @Post("/participate/invite")
-  inviteSchedule() {}
-
-  // TODO: 지도표시
+  @Post("/invite")
+  async inviteSchedule(@Token() token: string, @Body() dto: InviteScheduleDto) {
+    const result = await this.scheduleApiService.inviteSchedule(token, dto);
+    // return JSON.parse(result);
+  }
 }

--- a/be/src/schedule-api/schedule-api.service.ts
+++ b/be/src/schedule-api/schedule-api.service.ts
@@ -63,14 +63,27 @@ export class ScheduleApiService {
 
   async inviteSchedule(token: string, dto: InviteScheduleDto) {
     const userUuid = this.authService.verify(token);
-    const author = await this.userService.getUserEntity(userUuid);
-    const invited = await this.userService.getUserEntityByEmail(dto.invitedUserEmail);
+    const authorUser = await this.userService.getUserEntity(userUuid);
+    const invitedUser = await this.userService.getUserEntityByEmail(dto.invitedUserEmail);
 
     // 초대된 사람은 그 순간 미분류 카테고리에 속한 새로운 일정을 만들어야 하고
     // 그 일정의 metadata를 inviteSchedule()에 넣어주면 됨
 
-    const authorMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid(author.userUuid);
-    const invitedMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid(invited.userUuid);
+    const authorMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid(authorUser.userUuid);
+
+    const addScheduleDto: AddScheduleDto = {
+      userUuid: invitedUser.userUuid,
+      categoryUuid: "default",
+      title: "title",
+      endAt: "endAt",
+    };
+
+    const invitedScheduleMetadata = await this.scheduleMetaService.addScheduleMetadata(addScheduleDto, invitedUser);
+    const invitedHttpResponse = await this.scheduleService.addSchedule(addScheduleDto, invitedScheduleMetadata);
+
+    // invitedHttpResponse 파싱하여 scheduleuuid 넘겨주기
+
+    const invitedMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid("scheduleUuid");
     return await this.participateService.inviteSchedule(authorMetadataId, invitedMetadataId);
   }
 }

--- a/be/src/schedule-api/schedule-api.service.ts
+++ b/be/src/schedule-api/schedule-api.service.ts
@@ -10,6 +10,7 @@ import { ScheduleLocationService } from "src/schedule/schedule-location.service"
 import { AuthService } from "../auth/auth.service";
 import { RepetitionService } from "../schedule/repetition.service";
 import { ParticipateService } from "src/schedule/participate.service";
+import { InviteScheduleDto } from "src/schedule/dto/invite-schedule.dto";
 
 @Injectable()
 export class ScheduleApiService {
@@ -58,5 +59,18 @@ export class ScheduleApiService {
     dto.userUuid = this.authService.verify(token);
     const metadataId = await this.scheduleService.deleteSchedule(dto);
     return await this.scheduleMetaService.deleteScheduleMeta(metadataId);
+  }
+
+  async inviteSchedule(token: string, dto: InviteScheduleDto) {
+    const userUuid = this.authService.verify(token);
+    const author = await this.userService.getUserEntity(userUuid);
+    const invited = await this.userService.getUserEntityByEmail(dto.invitedUserEmail);
+
+    // 초대된 사람은 그 순간 미분류 카테고리에 속한 새로운 일정을 만들어야 하고
+    // 그 일정의 metadata를 inviteSchedule()에 넣어주면 됨
+
+    const authorMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid(author.userUuid);
+    const invitedMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid(invited.userUuid);
+    return await this.participateService.inviteSchedule(authorMetadataId, invitedMetadataId);
   }
 }

--- a/be/src/schedule-api/schedule-api.service.ts
+++ b/be/src/schedule-api/schedule-api.service.ts
@@ -63,27 +63,23 @@ export class ScheduleApiService {
 
   async inviteSchedule(token: string, dto: InviteScheduleDto) {
     const userUuid = this.authService.verify(token);
-    const authorUser = await this.userService.getUserEntity(userUuid);
+    const authorMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid(dto.scheduleUuid);
+    const endAt = await this.scheduleService.getEndAtByScheduleUuid(dto.scheduleUuid);
+
     const invitedUser = await this.userService.getUserEntityByEmail(dto.invitedUserEmail);
-
-    // 초대된 사람은 그 순간 미분류 카테고리에 속한 새로운 일정을 만들어야 하고
-    // 그 일정의 metadata를 inviteSchedule()에 넣어주면 됨
-
-    const authorMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid(authorUser.userUuid);
 
     const addScheduleDto: AddScheduleDto = {
       userUuid: invitedUser.userUuid,
       categoryUuid: "default",
       title: "title",
-      endAt: "endAt",
+      endAt,
     };
 
     const invitedScheduleMetadata = await this.scheduleMetaService.addScheduleMetadata(addScheduleDto, invitedUser);
     const invitedHttpResponse = await this.scheduleService.addSchedule(addScheduleDto, invitedScheduleMetadata);
+    const scheduleUuid = JSON.parse(invitedHttpResponse).data.scheduleUuid;
 
-    // invitedHttpResponse 파싱하여 scheduleuuid 넘겨주기
-
-    const invitedMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid("scheduleUuid");
+    const invitedMetadataId = await this.scheduleService.getMetadataIdByScheduleUuid(scheduleUuid);
     return await this.participateService.inviteSchedule(authorMetadataId, invitedMetadataId);
   }
 }

--- a/be/src/schedule/dto/add-schedule.dto.ts
+++ b/be/src/schedule/dto/add-schedule.dto.ts
@@ -1,4 +1,4 @@
-import {IsNotEmpty, IsObject, IsOptional, IsString, Matches} from "class-validator";
+import { IsNotEmpty, IsObject, IsOptional, IsString, Matches } from "class-validator";
 import { ScheduleLocationDto } from "src/schedule/dto/schedule-location.dto";
 import { RepetitionDto } from "./repetition.dto";
 

--- a/be/src/schedule/dto/invite-schedule.dto.ts
+++ b/be/src/schedule/dto/invite-schedule.dto.ts
@@ -1,7 +1,11 @@
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsEmail, IsNotEmpty, IsString } from "class-validator";
 
 export class InviteScheduleDto {
   @IsString()
   @IsNotEmpty()
-  categoryUuid: string;
+  scheduleUuid: string;
+
+  @IsEmail()
+  @IsNotEmpty()
+  invitedUserEmail: string;
 }

--- a/be/src/schedule/dto/update-schedule.dto.ts
+++ b/be/src/schedule/dto/update-schedule.dto.ts
@@ -1,6 +1,6 @@
-import { Allow, IsNotEmpty, IsObject, IsOptional, IsString, Matches } from "class-validator";
+import { Allow, IsArray, IsNotEmpty, IsObject, IsOptional, IsString, Matches } from "class-validator";
 import { ScheduleLocationDto } from "src/schedule/dto/schedule-location.dto";
-import {RepetitionDto} from "./repetition.dto";
+import { RepetitionDto } from "./repetition.dto";
 
 export class UpdateScheduleDto {
   userUuid: string;
@@ -41,4 +41,8 @@ export class UpdateScheduleDto {
   @IsObject()
   @IsOptional()
   repetition: RepetitionDto;
+
+  @IsArray()
+  @IsOptional()
+  participants: string[];
 }

--- a/be/src/schedule/dto/update-schedule.dto.ts
+++ b/be/src/schedule/dto/update-schedule.dto.ts
@@ -3,7 +3,7 @@ import { ScheduleLocationDto } from "src/schedule/dto/schedule-location.dto";
 import { RepetitionDto } from "./repetition.dto";
 
 export class UpdateScheduleDto {
-  userUuid: string;
+  userUuid?: string;
 
   @IsString()
   @IsNotEmpty()
@@ -40,9 +40,9 @@ export class UpdateScheduleDto {
 
   @IsObject()
   @IsOptional()
-  repetition: RepetitionDto;
+  repetition?: RepetitionDto;
 
   @IsArray()
   @IsOptional()
-  participants: string[];
+  participants?: string[];
 }

--- a/be/src/schedule/entity/participant.entity.ts
+++ b/be/src/schedule/entity/participant.entity.ts
@@ -15,6 +15,7 @@ export class ParticipantEntity extends BaseEntity {
   /*
    * relation
    */
+
   @OneToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.metadataId)
   @JoinColumn({ name: "participant_people_id" })
   participantPeople: ScheduleMetadataEntity;

--- a/be/src/schedule/entity/participant.entity.ts
+++ b/be/src/schedule/entity/participant.entity.ts
@@ -1,5 +1,4 @@
-import { BaseEntity, Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
-import { UserEntity } from "src/user/entity/user.entity";
+import { BaseEntity, Column, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 import { ScheduleMetadataEntity } from "./schedule-metadata.entity";
 
 @Entity("participant")
@@ -7,17 +6,16 @@ export class ParticipantEntity extends BaseEntity {
   @PrimaryGeneratedColumn({ name: "participant_id" })
   participantId: number;
 
-  @Column({ default: false })
-  author: boolean;
-
   /*
    * relation
    */
-
-  // participant 추가 시 삭제될 관계
-  @ManyToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.participant, {
-    onDelete: "CASCADE",
-  })
+  @OneToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.metadataId)
   @JoinColumn({ name: "metadata_id" })
   scheduleMeta: ScheduleMetadataEntity;
+
+  @ManyToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.author, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn()
+  author: ScheduleMetadataEntity;
 }

--- a/be/src/schedule/entity/participant.entity.ts
+++ b/be/src/schedule/entity/participant.entity.ts
@@ -6,10 +6,10 @@ export class ParticipantEntity extends BaseEntity {
   @PrimaryGeneratedColumn({ name: "participant_id" })
   participantId: number;
 
-  @Column({ name: "participant_people_id" })
+  @Column({ name: "participant_people_id", type: "int" })
   participantPeopleId: number;
 
-  @Column({ name: "author_id" })
+  @Column({ name: "author_id", type: "int" })
   authorId: number;
 
   /*
@@ -20,7 +20,7 @@ export class ParticipantEntity extends BaseEntity {
   participantPeople: ScheduleMetadataEntity;
 
   // participant 추가 시 삭제될 관계
-  @ManyToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.participant, {
+  @ManyToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.author, {
     onDelete: "CASCADE",
   })
   @JoinColumn({ name: "author_id" })

--- a/be/src/schedule/entity/participant.entity.ts
+++ b/be/src/schedule/entity/participant.entity.ts
@@ -6,16 +6,22 @@ export class ParticipantEntity extends BaseEntity {
   @PrimaryGeneratedColumn({ name: "participant_id" })
   participantId: number;
 
+  @Column({ name: "participant_people_id" })
+  participantPeopleId: number;
+
+  @Column({ name: "author_id" })
+  authorId: number;
+
   /*
    * relation
    */
   @OneToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.metadataId)
-  @JoinColumn({ name: "metadata_id" })
-  scheduleMeta: ScheduleMetadataEntity;
+  @JoinColumn({ name: "participant_people_id" })
+  participantPeople: ScheduleMetadataEntity;
 
   @ManyToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.author, {
     onDelete: "CASCADE",
   })
-  @JoinColumn()
+  @JoinColumn({ name: "author_id" })
   author: ScheduleMetadataEntity;
 }

--- a/be/src/schedule/entity/participant.entity.ts
+++ b/be/src/schedule/entity/participant.entity.ts
@@ -3,11 +3,11 @@ import { ScheduleMetadataEntity } from "./schedule-metadata.entity";
 
 @Entity("participant")
 export class ParticipantEntity extends BaseEntity {
-  @PrimaryGeneratedColumn({ name: "participant_id" })
-  participantId: number;
+  @PrimaryGeneratedColumn({ name: "id" })
+  id: number;
 
-  @Column({ name: "participant_people_id", type: "int" })
-  participantPeopleId: number;
+  @Column({ name: "participant_id", type: "int" })
+  participantId: number;
 
   @Column({ name: "author_id", type: "int" })
   authorId: number;
@@ -15,11 +15,10 @@ export class ParticipantEntity extends BaseEntity {
   /*
    * relation
    */
-  @OneToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.metadataId)
-  @JoinColumn({ name: "participant_people_id" })
-  participantPeople: ScheduleMetadataEntity;
+  @ManyToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.metadataId)
+  @JoinColumn({ name: "participant_id" })
+  participant: ScheduleMetadataEntity;
 
-  // participant 추가 시 삭제될 관계
   @ManyToOne(() => ScheduleMetadataEntity, (scheduleMeta) => scheduleMeta.author, {
     onDelete: "CASCADE",
   })

--- a/be/src/schedule/entity/schedule-metadata.entity.ts
+++ b/be/src/schedule/entity/schedule-metadata.entity.ts
@@ -45,10 +45,6 @@ export class ScheduleMetadataEntity extends BaseEntity {
   /*
    * relation
    */
-  @OneToMany(() => ScheduleEntity, (schedule) => schedule.parent, {
-    cascade: true,
-  })
-  children: ScheduleEntity[];
 
   @ManyToOne(() => UserEntity, (user) => user.scheduleMeta, {
     onDelete: "CASCADE",
@@ -62,9 +58,13 @@ export class ScheduleMetadataEntity extends BaseEntity {
   @JoinColumn({ name: "category_id" })
   category: CategoryEntity;
 
-  @OneToMany(() => ParticipantEntity, (participant) => participant.scheduleMeta, {
-    onDelete: "CASCADE",
+  @OneToMany(() => ScheduleEntity, (schedule) => schedule.parent, {
+    cascade: true,
   })
-  @JoinColumn({ name: "participant_id" })
-  participant: ParticipantEntity;
+  children: ScheduleEntity[];
+
+  @OneToMany(() => ParticipantEntity, (participant) => participant.author, {
+    cascade: true,
+  })
+  author: ParticipantEntity[];
 }

--- a/be/src/schedule/participate.repository.ts
+++ b/be/src/schedule/participate.repository.ts
@@ -1,8 +1,6 @@
 import { Injectable, InternalServerErrorException } from "@nestjs/common";
 import { Repository, DataSource } from "typeorm";
 import { ParticipantEntity } from "./entity/participant.entity";
-import { UserEntity } from "src/user/entity/user.entity";
-import { ScheduleMetadataEntity } from "./entity/schedule-metadata.entity";
 
 @Injectable()
 export class ParticipateRepository extends Repository<ParticipantEntity> {
@@ -12,14 +10,14 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
 
   async invite(authorMetadataId: number, invitedMetadataId: number): Promise<void> {
     if (this.isNotMade(authorMetadataId)) {
-      const record = this.create({ participantId: authorMetadataId, authorId: authorMetadataId });
-      this.save(record);
+      const authorRecord = this.create({ participantPeopleId: authorMetadataId, authorId: authorMetadataId });
+      await this.save(authorRecord);
     }
 
-    const record = this.create({ participantId: invitedMetadataId, authorId: authorMetadataId });
+    const participantRecord = this.create({ participantPeopleId: invitedMetadataId, authorId: authorMetadataId });
 
     try {
-      await this.save(record);
+      await this.save(participantRecord);
     } catch (error) {
       console.log(error);
       throw new InternalServerErrorException();
@@ -27,7 +25,7 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
   }
 
   // 만들어진 적 없으면 true
-  private isNotMade(authorMetadataId: number) {
-    return !this.findOne({ where: { authorId: authorMetadataId } });
+  private async isNotMade(authorMetadataId: number) {
+    return !(await this.findOne({ where: { authorId: authorMetadataId } }));
   }
 }

--- a/be/src/schedule/participate.repository.ts
+++ b/be/src/schedule/participate.repository.ts
@@ -9,7 +9,7 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
   }
 
   async invite(authorMetadataId: number, invitedMetadataId: number): Promise<void> {
-    if (this.isNotMade(authorMetadataId)) {
+    if (await this.isNotMade(authorMetadataId)) {
       const authorRecord = this.create({ participantPeopleId: authorMetadataId, authorId: authorMetadataId });
       await this.save(authorRecord);
     }
@@ -26,6 +26,6 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
 
   // 만들어진 적 없으면 true
   private async isNotMade(authorMetadataId: number) {
-    return !(await this.findOne({ where: { authorId: authorMetadataId } }));
+    return (await this.findOne({ where: { authorId: authorMetadataId } })) === null;
   }
 }

--- a/be/src/schedule/participate.repository.ts
+++ b/be/src/schedule/participate.repository.ts
@@ -10,10 +10,13 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
     super(ParticipantEntity, dataSource.createEntityManager());
   }
 
-  async addDefaultParticipantGroup(user: UserEntity, scheduleMeta: ScheduleMetadataEntity): Promise<void> {
-    const record = this.create({ scheduleMeta, author: scheduleMeta });
+  async invite(authorMetadataId: number, invitedMetadataId: number): Promise<void> {
+    if (this.isNotMade(authorMetadataId)) {
+      const record = this.create({ participantId: authorMetadataId, authorId: authorMetadataId });
+      this.save(record);
+    }
 
-    console.log(record);
+    const record = this.create({ participantId: invitedMetadataId, authorId: authorMetadataId });
 
     try {
       await this.save(record);
@@ -21,5 +24,10 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
       console.log(error);
       throw new InternalServerErrorException();
     }
+  }
+
+  // 만들어진 적 없으면 true
+  private isNotMade(authorMetadataId: number) {
+    return !this.findOne({ where: { authorId: authorMetadataId } });
   }
 }

--- a/be/src/schedule/participate.repository.ts
+++ b/be/src/schedule/participate.repository.ts
@@ -11,7 +11,7 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
   }
 
   async addDefaultParticipantGroup(user: UserEntity, scheduleMeta: ScheduleMetadataEntity): Promise<void> {
-    const record = this.create({ author: true, scheduleMeta });
+    const record = this.create({ scheduleMeta, author: scheduleMeta });
 
     console.log(record);
 

--- a/be/src/schedule/participate.service.ts
+++ b/be/src/schedule/participate.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { ParticipateRepository } from "./participate.repository";
+import { ScheduleMetadataEntity } from "./entity/schedule-metadata.entity";
 
 @Injectable()
 export class ParticipateService {
@@ -9,7 +10,7 @@ export class ParticipateService {
     private participateRepository: ParticipateRepository,
   ) {}
 
-  async inviteSchedule(authorMetadataId: number, invitedMetadataId: number) {
-    await this.participateRepository.invite(authorMetadataId, invitedMetadataId);
+  async inviteSchedule(authorScheduleMetadata: ScheduleMetadataEntity, invitedMetadataId: number) {
+    await this.participateRepository.invite(authorScheduleMetadata, invitedMetadataId);
   }
 }

--- a/be/src/schedule/participate.service.ts
+++ b/be/src/schedule/participate.service.ts
@@ -1,12 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { AddScheduleDto } from "./dto/add-schedule.dto";
-import { DeleteScheduleDto } from "./dto/delete-schedule.dto";
-import { UpdateScheduleDto } from "./dto/update-schedule.dto";
-import { ScheduleMetadataEntity } from "./entity/schedule-metadata.entity";
-import { ScheduleRepository } from "./schedule.repository";
 import { ParticipateRepository } from "./participate.repository";
-import { UserEntity } from "src/user/entity/user.entity";
 
 @Injectable()
 export class ParticipateService {
@@ -15,7 +9,7 @@ export class ParticipateService {
     private participateRepository: ParticipateRepository,
   ) {}
 
-  async addDefaultParticipantGroup(user: UserEntity, scheduleMeta: ScheduleMetadataEntity) {
-    await this.participateRepository.addDefaultParticipantGroup(user, scheduleMeta);
+  async inviteSchedule(authorMetadataId: number, invitedMetadataId: number) {
+    await this.participateRepository.invite(authorMetadataId, invitedMetadataId);
   }
 }

--- a/be/src/schedule/schedule-location.service.ts
+++ b/be/src/schedule/schedule-location.service.ts
@@ -66,7 +66,12 @@ export class ScheduleLocationService {
     try {
       await this.scheduleLocationRepository.save(record);
     } catch (error) {
+      console.log(error);
       throw new InternalServerErrorException();
     }
+  }
+
+  async getLocationByScheduleMetadataId(scheduleMetaId: number): Promise<ScheduleLocationEntity> {
+    return await this.scheduleLocationRepository.findOne({ where: { metadataId: scheduleMetaId } });
   }
 }

--- a/be/src/schedule/schedule-meta.service.ts
+++ b/be/src/schedule/schedule-meta.service.ts
@@ -19,7 +19,7 @@ export class ScheduleMetaService {
   async addScheduleMetadata(
     dto: AddScheduleDto,
     user: UserEntity,
-    category: CategoryEntity,
+    category: CategoryEntity = null,
   ): Promise<ScheduleMetadataEntity> {
     const { title, endAt } = dto;
 

--- a/be/src/schedule/schedule.repository.ts
+++ b/be/src/schedule/schedule.repository.ts
@@ -51,7 +51,7 @@ export class ScheduleRepository extends Repository<ScheduleEntity> {
     return record.metadataId;
   }
 
-  async updateSchedule(dto: UpdateScheduleDto): Promise<string> {
+  async updateSchedule(dto: UpdateScheduleDto): Promise<void> {
     const { scheduleUuid, startAt, endAt } = dto;
     const record = await this.findOne({ where: { scheduleUuid } });
     record.startAt = startAt;
@@ -59,14 +59,6 @@ export class ScheduleRepository extends Repository<ScheduleEntity> {
 
     try {
       await this.save(record);
-      const body: HttpResponse = {
-        message: "일정 수정 성공",
-        data: {
-          scheduleUuid: scheduleUuid,
-        },
-      };
-
-      return JSON.stringify(body);
     } catch (error) {
       console.log(error);
       throw new InternalServerErrorException();

--- a/be/src/schedule/schedule.service.ts
+++ b/be/src/schedule/schedule.service.ts
@@ -5,6 +5,7 @@ import { ScheduleMetadataEntity } from "./entity/schedule-metadata.entity";
 import { ScheduleRepository } from "./schedule.repository";
 import { UpdateScheduleDto } from "./dto/update-schedule.dto";
 import { DeleteScheduleDto } from "./dto/delete-schedule.dto";
+import { ScheduleEntity } from "./entity/schedule.entity";
 
 @Injectable()
 export class ScheduleService {
@@ -30,8 +31,7 @@ export class ScheduleService {
     return await this.scheduleRepository.deleteSchedule(dto);
   }
 
-  async getEndAtByScheduleUuid(scheduleUuid: string): Promise<string> {
-    const record = await this.scheduleRepository.findOne({ where: { scheduleUuid } });
-    return record.endAt;
+  async getScheduleEntityByScheduleUuid(scheduleUuid: string): Promise<ScheduleEntity> {
+    return await this.scheduleRepository.findOne({ where: { scheduleUuid }, relations: ["parent"] });
   }
 }

--- a/be/src/schedule/schedule.service.ts
+++ b/be/src/schedule/schedule.service.ts
@@ -29,4 +29,9 @@ export class ScheduleService {
   async deleteSchedule(dto: DeleteScheduleDto) {
     return await this.scheduleRepository.deleteSchedule(dto);
   }
+
+  async getEndAtByScheduleUuid(scheduleUuid: string): Promise<string> {
+    const record = await this.scheduleRepository.findOne({ where: { scheduleUuid } });
+    return record.endAt;
+  }
 }

--- a/be/src/schedule/schedule.service.ts
+++ b/be/src/schedule/schedule.service.ts
@@ -22,9 +22,9 @@ export class ScheduleService {
     return await this.scheduleRepository.getMetadataIdByScheduleUuid(scheduleUuid);
   }
 
-  async updateSchedule(dto: UpdateScheduleDto): Promise<string> {
+  async updateSchedule(dto: UpdateScheduleDto): Promise<void> {
     // TODO: repetition 기준으로 추가
-    return await this.scheduleRepository.updateSchedule(dto);
+    await this.scheduleRepository.updateSchedule(dto);
   }
 
   async deleteSchedule(dto: DeleteScheduleDto) {

--- a/be/src/user/user.repository.ts
+++ b/be/src/user/user.repository.ts
@@ -41,4 +41,15 @@ export class UserRepository extends Repository<UserEntity> {
     }
     return user;
   }
+
+  async findByEmail(userEmail: string) {
+    const user = await this.findOne({
+      where: { email: userEmail },
+    });
+
+    if (user === null) {
+      throw new UnauthorizedException("존재하지 않는 user");
+    }
+    return user;
+  }
 }

--- a/be/src/user/user.service.ts
+++ b/be/src/user/user.service.ts
@@ -84,4 +84,8 @@ export class UserService {
   async getUserEntityById(userId: number): Promise<UserEntity> {
     return await this.userRepository.findById(userId);
   }
+
+  async getUserEntityByEmail(userEmail: string): Promise<UserEntity> {
+    return await this.userRepository.findByEmail(userEmail);
+  }
 }


### PR DESCRIPTION
### 일정 초대 기능 구현

- 동작 예시

user_id = 1인 사용자가 user_id = 2, 3인 사용자를 본인의 일정 (metadata_id = 1)에 초대하는 상황 

초대 코드 실행 시, 본인의 일정과 모든 정보 (title, description, endAt, location 등등)가 동일한 일정 2개가 복사되어 user_id = 2, 3에게 할당됨 
![스크린샷 2023-11-28 225646](https://github.com/boostcampwm2023/and02-PlanJ/assets/35479251/7b4b4a65-a335-42ee-94e6-08f44a995b0b)
![스크린샷 2023-11-28 225704](https://github.com/boostcampwm2023/and02-PlanJ/assets/35479251/3faf2daf-cc1c-4d63-b3d4-a45aacce648b)
![스크린샷 2023-11-28 225717](https://github.com/boostcampwm2023/and02-PlanJ/assets/35479251/51cc655b-7a5c-4222-a1ae-2414f554fbd2)


participant 테이블에는 metadata_id=1인 일정이 author로, 나머지 복사된 2개의 일정 (metadata_id = 15, 16)이 참가자로 표시되어 기록됨 
![스크린샷 2023-11-28 225622](https://github.com/boostcampwm2023/and02-PlanJ/assets/35479251/5f0f6eb3-288d-4130-8727-73cfd56094c4)


+ participant.repository.ts의 if (isNotMade) 구문이 제대로 작동하지 않아 author 정보가 중복되어 들어가는 문제가 있음 
