### PR TITLE
[K026, K041] 일정 라디오, 삭제 api 연결, 카테고리 상세 일정 api, 설정 프로필 화면 삭제  및 로그인 버그 수정, 모듈 분리

### DIFF
--- a/PlanJ/app/build.gradle.kts
+++ b/PlanJ/app/build.gradle.kts
@@ -80,11 +80,6 @@ android {
         correctErrorTypes = true
     }
 
-    packagingOptions {
-        exclude ("com/navercorp/nid/NaverIdLoginSDK.class")
-        exclude ("com/navercorp/nid/cookie/NidOAuthCookieManager.class")
-        exclude ("com/navercorp/nid/exception/NaverIdLoginSDKNotInitializedException.class")
-    }
 
     configurations.all {
         resolutionStrategy {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/LogInModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/LogInModule.kt
@@ -1,10 +1,19 @@
 package com.boostcamp.planj.data.di
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.room.Room
 import com.boostcamp.planj.BuildConfig
+import com.boostcamp.planj.data.db.AlarmInfoDao
+import com.boostcamp.planj.data.db.AppDatabase
 import com.boostcamp.planj.data.network.LoginApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -51,4 +60,27 @@ object LogInModule {
         return retrofit.create(LoginApi::class.java)
     }
 
+
+    //room
+    @Singleton
+    @Provides
+    fun provideRoom(@ApplicationContext context: Context): AppDatabase {
+        return Room.databaseBuilder(
+            context,
+            AppDatabase::class.java,
+            "planj"
+        ).build()
+    }
+
+    @Singleton
+    @Provides
+    fun provideAlarmInfoDao(appDatabase: AppDatabase): AlarmInfoDao = appDatabase.alarmInfoDao()
+
+    //DataStore
+    @Singleton
+    @Provides
+    fun providePreferencesDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile(BuildConfig.DATA_STORE_NAME) }
+        )
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/MainModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/MainModule.kt
@@ -1,43 +1,28 @@
 package com.boostcamp.planj.data.di
 
-import android.content.Context
 import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStoreFile
-import androidx.room.Room
-import androidx.room.RoomDatabase
-import androidx.sqlite.db.SupportSQLiteDatabase
 import com.boostcamp.planj.BuildConfig
-import com.boostcamp.planj.data.db.AlarmInfoDao
-import com.boostcamp.planj.data.db.AppDatabase
-import com.boostcamp.planj.data.model.Category
 import com.boostcamp.planj.data.network.MainApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import dagger.hilt.android.components.ActivityRetainedComponent
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import javax.inject.Singleton
 
 @Module
-@InstallIn(SingletonComponent::class)
+@InstallIn(ActivityRetainedComponent::class)
 object MainModule {
 
 
-    @Singleton
     @Provides
     fun provideInterceptor(datastore: DataStore<Preferences>): Interceptor {
         val user = stringPreferencesKey(BuildConfig.USER)
@@ -60,7 +45,6 @@ object MainModule {
     }
 
     //retrofit
-    @Singleton
     @Provides
     fun provideOkHttpClient(interceptor: Interceptor): OkHttpClient {
         val httpLoggingInterceptor = HttpLoggingInterceptor()
@@ -71,7 +55,6 @@ object MainModule {
             .build()
     }
 
-    @Singleton
     @Provides
     fun provideRetrofitInstance(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
@@ -81,35 +64,10 @@ object MainModule {
             .build()
     }
 
-    @Singleton
     @Provides
     fun provideService(retrofit: Retrofit): MainApi {
         return retrofit.create(MainApi::class.java)
     }
 
-    //okhttp
-
-    //room
-    @Singleton
-    @Provides
-    fun provideRoom(@ApplicationContext context: Context): AppDatabase {
-        return Room.databaseBuilder(
-            context,
-            AppDatabase::class.java,
-            "planj"
-        ).build()
-    }
-
-    @Singleton
-    @Provides
-    fun provideAlarmInfoDao(appDatabase: AppDatabase): AlarmInfoDao = appDatabase.alarmInfoDao()
-
-    //DataStore
-    @Singleton
-    @Provides
-    fun providePreferencesDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
-        PreferenceDataStoreFactory.create(
-            produceFile = { context.preferencesDataStoreFile(BuildConfig.DATA_STORE_NAME) }
-        )
 
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/MainRepositoryModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/MainRepositoryModule.kt
@@ -1,0 +1,33 @@
+package com.boostcamp.planj.data.di
+
+import com.boostcamp.planj.data.repository.MainRepository
+import com.boostcamp.planj.data.repository.MainRepositoryImpl
+import com.boostcamp.planj.data.repository.NaverRepository
+import com.boostcamp.planj.data.repository.NaverRepositoryImpl
+import com.boostcamp.planj.data.repository.SearchRepository
+import com.boostcamp.planj.data.repository.SearchRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.hilt.components.SingletonComponent
+
+@InstallIn(ActivityRetainedComponent::class)
+@Module
+abstract class MainRepositoryModule {
+    @Binds
+    abstract fun provideMainRepository(
+        mainRepositoryImpl: MainRepositoryImpl
+    ): MainRepository
+
+    @Binds
+    abstract fun provideSearchRepository(
+        searchRepositoryImpl: SearchRepositoryImpl
+    ): SearchRepository
+
+    @Binds
+    abstract fun provideNaverRepository(
+        naverRepository: NaverRepositoryImpl
+    ): NaverRepository
+}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/NaverDirectionModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/NaverDirectionModule.kt
@@ -10,6 +10,8 @@ import com.boostcamp.planj.data.network.NaverApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.components.ActivityRetainedComponent
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/RepositoryModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/RepositoryModule.kt
@@ -21,19 +21,5 @@ abstract class RepositoryModule {
     abstract fun provideLoginRepository(
         loginRepositoryImpl: LoginRepositoryImpl
     ): LoginRepository
-
-    @Binds
-    abstract fun provideMainRepository(
-        mainRepositoryImpl: MainRepositoryImpl
-    ): MainRepository
-
-    @Binds
-    abstract fun provideSearchRepository(
-        searchRepositoryImpl: SearchRepositoryImpl
-    ): SearchRepository
-
-    @Binds
-    abstract fun provideNaverRepository(
-        naverRepository: NaverRepositoryImpl
-    ): NaverRepository
+    
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/SearchMapModule.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/di/SearchMapModule.kt
@@ -1,19 +1,17 @@
 package com.boostcamp.planj.data.di
 
-import android.util.Log
 import com.boostcamp.planj.BuildConfig
 import com.boostcamp.planj.data.network.KaKaoSearchApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
 import dagger.hilt.components.SingletonComponent
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.create
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
@@ -30,7 +28,7 @@ object SearchMapModule {
     @Singleton
     @Provides
     @Map
-    fun provideInterceptor() : Interceptor {
+    fun provideInterceptor(): Interceptor {
         return Interceptor { chain ->
             var request = chain.request()
             request = request.newBuilder()
@@ -63,10 +61,9 @@ object SearchMapModule {
             .build()
     }
 
-
     @Singleton
     @Provides
-    fun provideRetrofit(@Map retrofit: Retrofit) : KaKaoSearchApi {
+    fun provideRetrofit(@Map retrofit: Retrofit): KaKaoSearchApi {
         return retrofit.create(KaKaoSearchApi::class.java)
     }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Category.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/Category.kt
@@ -1,11 +1,14 @@
 package com.boostcamp.planj.data.model
 
+import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
 
 
+@Parcelize
 data class Category(
     @SerializedName("categoryUuid") val categoryUuid: String,
     @SerializedName("categoryName") val categoryName: String
-)
+) : Parcelable

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/dto/GetScheduleCheckedResponse.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/dto/GetScheduleCheckedResponse.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.planj.data.model.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class GetScheduleCheckedResponse(
+    @SerializedName("message") val message:String,
+    @SerializedName("isFail") val isFail:Boolean,
+    @SerializedName("isWrite") val isWrite:Boolean
+)

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/MainApi.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/MainApi.kt
@@ -83,6 +83,9 @@ interface MainApi {
         @Part profileImage: MultipartBody.Part?
     ): PostUserResponse
 
+    @PATCH("/api/auth/set-default-image")
+    suspend fun patchUserImageRemove()
+
     @GET("/api/schedule/check")
     suspend fun getScheduleChecked(@Query("scheduleUuid") scheduleUuid: String): GetScheduleCheckedResponse
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/MainApi.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/MainApi.kt
@@ -8,6 +8,7 @@ import com.boostcamp.planj.data.model.dto.GetFriendResponse
 import com.boostcamp.planj.data.model.dto.GetSchedulesResponse
 import com.boostcamp.planj.data.model.dto.GetUserInfoResponse
 import com.boostcamp.planj.data.model.dto.CategoryResponse
+import com.boostcamp.planj.data.model.dto.GetScheduleCheckedResponse
 import com.boostcamp.planj.data.model.dto.PatchScheduleBody
 import com.boostcamp.planj.data.model.dto.PatchScheduleResponse
 import com.boostcamp.planj.data.model.dto.PostCategoryBody
@@ -82,6 +83,7 @@ interface MainApi {
         @Part profileImage: MultipartBody.Part?
     ): PostUserResponse
 
-
+    @GET("/api/schedule/check")
+    suspend fun getScheduleChecked(@Query("scheduleUuid") scheduleUuid: String): GetScheduleCheckedResponse
 
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/LoginRepository.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/LoginRepository.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.planj.data.repository
 
 
+import com.boostcamp.planj.data.model.AlarmInfo
 import com.boostcamp.planj.data.model.dto.LoginResponse
 import com.boostcamp.planj.data.network.ApiResult
 import kotlinx.coroutines.flow.Flow
@@ -15,10 +16,28 @@ interface LoginRepository {
 
     suspend fun postSignIn(userEmail: String, userPwd: String): ApiResult<LoginResponse>
 
-    fun getUser() : Flow<String>
+    fun getToken() : Flow<String>
 
     suspend fun saveUser(id : String)
 
     fun postSignInNaver(accessToken : String) : Flow<LoginResponse>
+
+    suspend fun updateAlarmInfo(curTimeMillis: Long)
+
+    suspend fun getAllAlarmInfo(): List<AlarmInfo>
+
+    suspend fun deleteAllData()
+
+    suspend fun insertAlarmInfo(alarmInfo: AlarmInfo)
+
+
+    suspend fun deleteAlarmInfo(alarmInfo: AlarmInfo)
+
+    suspend fun deleteAlarmInfoUsingScheduleId(scheduleId: String)
+
+    suspend fun saveAlarmMode(mode: Boolean)
+
+    fun getAlarmMode(): Flow<Boolean>
+
 
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
@@ -7,6 +7,7 @@ import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.data.model.User
 import com.boostcamp.planj.data.model.dto.GetSchedulesResponse
 import com.boostcamp.planj.data.model.dto.CategoryResponse
+import com.boostcamp.planj.data.model.dto.GetScheduleCheckedResponse
 import com.boostcamp.planj.data.model.dto.PatchScheduleBody
 import com.boostcamp.planj.data.model.dto.PatchScheduleResponse
 import com.boostcamp.planj.data.model.dto.PostCategoryBody
@@ -73,4 +74,6 @@ interface MainRepository {
     suspend fun updateAlarmInfo(curTimeMillis: Long)
 
     suspend fun getDetailSchedule(scheduleId: String): ScheduleDetail
+
+    fun getScheduleChecked(scheduleId: String):Flow<GetScheduleCheckedResponse>
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
@@ -24,8 +24,6 @@ interface MainRepository {
 
     fun postSchedule(categoryId: String, title: String, endTime: DateTime): Flow<PostScheduleResponse>
 
-    fun getToken(): Flow<String>
-
     suspend fun emptyToken()
 
     suspend fun deleteScheduleApi(scheduleUuid: String)
@@ -57,23 +55,9 @@ interface MainRepository {
 
     fun patchUser(nickName : String, imageFile : MultipartBody.Part?) : Flow<PostUserResponse>
 
-    suspend fun saveAlarmMode(mode: Boolean)
-
-    suspend fun getAlarmMode(): Flow<Boolean>
-
-    suspend fun deleteAllData()
-
-    suspend fun insertAlarmInfo(alarmInfo: AlarmInfo)
-
-    suspend fun getAllAlarmInfo(): List<AlarmInfo>
-
-    suspend fun deleteAlarmInfo(alarmInfo: AlarmInfo)
-
-    suspend fun deleteAlarmInfoUsingScheduleId(scheduleId: String)
-
-    suspend fun updateAlarmInfo(curTimeMillis: Long)
-
     suspend fun getDetailSchedule(scheduleId: String): ScheduleDetail
 
     fun getScheduleChecked(scheduleId: String):Flow<GetScheduleCheckedResponse>
+
+    suspend fun getUserImageRemove()
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
@@ -38,7 +38,7 @@ interface MainRepository {
         categoryName: String
     ): Flow<CategoryResponse>
 
-    suspend fun getCategoryListApi(): Flow<List<Category>>
+    fun getCategoryListApi(): Flow<List<Category>>
 
     suspend fun getCategorySchedulesApi(categoryUuid: String): Flow<GetSchedulesResponse>
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
@@ -106,7 +106,7 @@ class MainRepositoryImpl @Inject constructor(
         emit(api.patchCategory(Category(categoryUuid, categoryName)))
     }
 
-    override suspend fun getCategoryListApi(): Flow<List<Category>> = flow {
+    override fun getCategoryListApi(): Flow<List<Category>> = flow {
         emit(api.getCategoryList().data)
     }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
@@ -41,7 +41,6 @@ import javax.inject.Inject
 class MainRepositoryImpl @Inject constructor(
     private val api: MainApi,
     private val dataStore: DataStore<Preferences>,
-    private val alarmInfoDao: AlarmInfoDao,
 ) : MainRepository {
 
     companion object {
@@ -65,23 +64,8 @@ class MainRepositoryImpl @Inject constructor(
 
     override suspend fun emptyToken() {
         dataStore.edit { prefs ->
-            prefs[USER] = ""
+            prefs.clear()
         }
-    }
-
-    override fun getToken(): Flow<String> {
-        return dataStore.data
-            .catch { e ->
-                if (e is IOException) {
-                    e.printStackTrace()
-                    emit(emptyPreferences())
-                } else {
-                    throw e
-                }
-            }
-            .map { pref ->
-                pref[USER] ?: ""
-            }
     }
 
     override suspend fun deleteScheduleApi(scheduleUuid: String) {
@@ -112,40 +96,42 @@ class MainRepositoryImpl @Inject constructor(
 
     override suspend fun getCategorySchedulesApi(categoryUuid: String): Flow<GetSchedulesResponse> =
         flow {
-            try {
-                val scheduleInfo = api.getCategorySchedule(categoryUuid)
-                val scheduleDummy = scheduleInfo.date.map {
-
-                    val startAt =
-                        it.startAt?.split("T", "-", ":")?.map { time -> time.toInt() } ?: emptyList()
-                    val endAt = it.endAt.split("T", "-", ":").map { time -> time.toInt() }
-
-                    Schedule(
-                        scheduleId = it.scheduleUuid,
-                        title = it.title,
-                        startAt = if (startAt.isEmpty()) null else DateTime(
-                            startAt[0],
-                            startAt[1],
-                            startAt[2],
-                            startAt[3],
-                            startAt[4],
-                            startAt[5]
-                        ),
-                        endAt = DateTime(endAt[0], endAt[1], endAt[2], endAt[3], endAt[4], endAt[5]),
-                        isFinished = it.isFinished,
-                        isFailed = it.isFailed,
-                        repeated = it.repeated,
-                        hasRetrospectiveMemo = it.hasRetrospectiveMemo,
-                        shared = it.shared,
-                        participantCount = it.participantCount,
-                        participantSuccessCount = it.participantSuccessCount
-                    )
-                }
-                emit(GetSchedulesResponse("",scheduleDummy))
-
-            } catch (e: Exception) {
-                Log.d("PLANJDEBUG", "getCategorySchedulesApi error  ${e.message}")
-            }
+//            try {
+//                val scheduleInfo = api.getCategorySchedule(categoryUuid)
+//                val scheduleDummy = scheduleInfo.date.map {
+//
+//                    Log.d("PLANJDEBUG", "${it.startAt}, ${it.endAt}")
+//
+//                    val startAt =
+//                        it.startAt?.split("T", "-", ":")?.map { time -> time.toInt() } ?: emptyList()
+//                    val endAt = it.endAt.split("T", "-", ":").map { time -> time.toInt() }
+//                    Schedule(
+//                        scheduleId = it.scheduleUuid,
+//                        title = it.title,
+//                        startAt = if (startAt.isEmpty()) null else DateTime(
+//                            startAt[0],
+//                            startAt[1],
+//                            startAt[2],
+//                            startAt[3],
+//                            startAt[4],
+//                            startAt[5]
+//                        ),
+//                        endAt = DateTime(endAt[0], endAt[1], endAt[2], endAt[3], endAt[4], endAt[5]),
+//                        isFinished = it.isFinished,
+//                        isFailed = it.isFailed,
+//                        repeated = it.repeated,
+//                        hasRetrospectiveMemo = it.hasRetrospectiveMemo,
+//                        shared = it.shared,
+//                        participantCount = it.participantCount,
+//                        participantSuccessCount = it.participantSuccessCount
+//                    )
+//                }
+//                emit(scheduleDummy)
+//
+//            } catch (e: Exception) {
+//                Log.d("PLANJDEBUG", "getCategorySchedulesApi error ${e.message}")
+//            }
+            emit(api.getCategorySchedule(categoryUuid))
         }
 
     override suspend fun getWeeklyScheduleApi(date: String): Flow<GetSchedulesResponse> = flow {
@@ -212,89 +198,6 @@ class MainRepositoryImpl @Inject constructor(
         emit(api.patchUser(nickName, imageFile))
     }
 
-    override suspend fun saveAlarmMode(mode: Boolean) {
-        dataStore.edit { prefs ->
-            prefs[ALARM_MODE] = mode
-        }
-    }
-
-    override suspend fun getAlarmMode(): Flow<Boolean> {
-        return dataStore.data
-            .catch { exception ->
-                if (exception is IOException) {
-                    exception.printStackTrace()
-                    emit(emptyPreferences())
-                } else {
-                    throw exception
-                }
-
-            }
-            .map { prefs ->
-                prefs[ALARM_MODE] ?: true
-            }
-    }
-
-    override suspend fun deleteAllData() {
-        alarmInfoDao.deleteAllAlarmInfo()
-    }
-
-    override suspend fun insertAlarmInfo(alarmInfo: AlarmInfo) {
-        alarmInfoDao.insertAlarmInfo(alarmInfo)
-    }
-
-    override suspend fun getAllAlarmInfo(): List<AlarmInfo> {
-        return alarmInfoDao.getAll()
-    }
-
-    override suspend fun deleteAlarmInfo(alarmInfo: AlarmInfo) {
-        alarmInfoDao.deleteAlarmInfo(alarmInfo)
-    }
-
-    override suspend fun deleteAlarmInfoUsingScheduleId(scheduleId: String) {
-        alarmInfoDao.deleteAlarmInfoUsingScheduleId(scheduleId)
-    }
-
-    override suspend fun updateAlarmInfo(curTimeMillis: Long) {
-        val alarmList = alarmInfoDao.getAll()
-        val calendar = Calendar.getInstance()
-        alarmList.forEach { alarmInfo ->
-            calendar.timeInMillis = alarmInfo.endTime.toMilliseconds()
-            calendar.add(Calendar.MINUTE, -alarmInfo.alarm.alarmTime - alarmInfo.estimatedTime)
-
-            // 알림 시간 < 현재 시간 -> 알람 삭제 or 업데이트
-            if (calendar.timeInMillis < curTimeMillis) {
-                // 일회성 -> 알림 DB에서 삭제
-                // 반복 -> DB 업데이트
-                if (alarmInfo.repetition == null) {
-                    alarmInfoDao.deleteAlarmInfo(alarmInfo)
-                } else {
-                    val oneDayMillis = 24 * 60 * 60 * 1000L
-                    val interval = if (alarmInfo.repetition.cycleType == "DAILY") {
-                        alarmInfo.repetition.cycleCount
-                    } else {
-                        alarmInfo.repetition.cycleCount * 7
-                    }
-                    while (calendar.timeInMillis < curTimeMillis) {
-                        calendar.timeInMillis += (interval * oneDayMillis)
-                    }
-                    calendar.add(
-                        Calendar.MINUTE,
-                        alarmInfo.alarm.alarmTime + alarmInfo.estimatedTime
-                    )
-                    val endTime = DateTime(
-                        calendar.get(Calendar.YEAR),
-                        calendar.get(Calendar.MONTH) + 1,
-                        calendar.get(Calendar.DAY_OF_MONTH),
-                        calendar.get(Calendar.HOUR_OF_DAY),
-                        calendar.get(Calendar.MINUTE)
-                    )
-                    alarmInfoDao.updateAlarmInfo(
-                        alarmInfo.copy(endTime = endTime)
-                    )
-                }
-            }
-        }
-    }
 
     override suspend fun getDetailSchedule(scheduleId: String): ScheduleDetail {
         return api.getDetailSchedule(scheduleId).scheduleDetail
@@ -303,5 +206,8 @@ class MainRepositoryImpl @Inject constructor(
     override fun getScheduleChecked(scheduleId: String): Flow<GetScheduleCheckedResponse> =
         flow { emit(api.getScheduleChecked(scheduleId)) }
 
+    override suspend fun getUserImageRemove() {
+        return api.patchUserImageRemove()
+    }
 }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/RestartAlarmReceiver.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/RestartAlarmReceiver.kt
@@ -3,6 +3,7 @@ package com.boostcamp.planj.ui
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.boostcamp.planj.data.repository.LoginRepository
 import com.boostcamp.planj.data.repository.MainRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -14,14 +15,14 @@ import javax.inject.Inject
 class RestartAlarmReceiver : BroadcastReceiver() {
 
     @Inject
-    lateinit var mainRepository: MainRepository
+    lateinit var loginRepository: LoginRepository
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == "android.intent.action.BOOT_COMPLETED") {
             val alarm = PlanjAlarm(context)
             CoroutineScope(Dispatchers.IO).launch {
-                mainRepository.updateAlarmInfo(System.currentTimeMillis())
-                val alarmList = mainRepository.getAllAlarmInfo()
+                loginRepository.updateAlarmInfo(System.currentTimeMillis())
+                val alarmList = loginRepository.getAllAlarmInfo()
                 alarmList.forEach { alarmInfo -> alarm.setAlarm(alarmInfo) }
             }
         }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/adapter/ScheduleAdapterViewHolder.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/adapter/ScheduleAdapterViewHolder.kt
@@ -15,8 +15,8 @@ class ScheduleAdapterViewHolder(private val binding: ItemScheduleBinding) :
         itemView.setOnClickListener {
             clickListener.onClick(item)
         }
-        binding.cbDone.setOnCheckedChangeListener { _ , isChecked ->
-            checkBoxListener.onClick(item, isChecked)
+        binding.cbDone.setOnCheckedChangeListener { _ , _ ->
+            checkBoxListener.onClick(item)
         }
     }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/adapter/ScheduleDoneListener.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/adapter/ScheduleDoneListener.kt
@@ -3,5 +3,5 @@ package com.boostcamp.planj.ui.adapter
 import com.boostcamp.planj.data.model.Schedule
 
 fun interface ScheduleDoneListener {
-    fun onClick(schedule : Schedule, isClick : Boolean)
+    fun onClick(schedule : Schedule)
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailActivity.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailActivity.kt
@@ -21,8 +21,8 @@ class CategoryDetailActivity : AppCompatActivity() {
         binding.lifecycleOwner = this
         setContentView(binding.root)
 
-        val title = args.categoryId
-        viewModel.setTitle(title)
+        val category = args.category
+        viewModel.setTitle(category)
     }
 
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailFragment.kt
@@ -51,7 +51,7 @@ class CategoryDetailFragment : Fragment() {
         binding.fbCategoryDetailAddSchedule.setOnClickListener {
             val dialog = ScheduleDialog(
                 emptyList(),
-                initText = viewModel.title.value
+                initText = viewModel.category.value.categoryName
             ) { category, title, endTime ->
                 viewModel.postSchedule(category, title, endTime)
             }
@@ -106,6 +106,7 @@ class CategoryDetailFragment : Fragment() {
                 }
             }
         }
+
 
     }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailFragment.kt
@@ -42,6 +42,8 @@ class CategoryDetailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewmodel = viewModel
+        binding.lifecycleOwner=viewLifecycleOwner
+
         initAdapter()
         setObserver()
         setListener()
@@ -79,8 +81,8 @@ class CategoryDetailFragment : Fragment() {
                 CategoryDetailFragmentDirections.actionCategoryDetailFragmentToScheduleActivity(it.scheduleId)
             findNavController().navigate(action)
         }
-        val checkBoxListener = ScheduleDoneListener { schedule, isCheck ->
-            viewModel.checkBoxChange(schedule, isCheck)
+        val checkBoxListener = ScheduleDoneListener { schedule ->
+            viewModel.checkBoxChange(schedule, !schedule.isFinished)
         }
         segmentScheduleAdapter = SegmentScheduleAdapter(swipeListener, scheduleClickListener, checkBoxListener)
         binding.rvCategoryDetail.adapter = segmentScheduleAdapter

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailFragment.kt
@@ -43,7 +43,7 @@ class CategoryDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.viewmodel = viewModel
         binding.lifecycleOwner=viewLifecycleOwner
-
+        viewModel.getCategoryDetailSchedules()
         initAdapter()
         setObserver()
         setListener()

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.boostcamp.planj.ui.categorydetail
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.boostcamp.planj.data.model.Category
 import com.boostcamp.planj.data.model.DateTime
 import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.data.repository.MainRepository
@@ -24,8 +25,8 @@ class CategoryDetailViewModel @Inject constructor(
     private val mainRepository: MainRepository
 ) : ViewModel() {
 
-    private val _title = MutableStateFlow("")
-    val title: StateFlow<String> = _title.asStateFlow()
+    private val _cateogry = MutableStateFlow(Category("", ""))
+    val category: StateFlow<Category> = _cateogry.asStateFlow()
 
     private val _schedules = MutableStateFlow<List<Schedule>>(emptyList())
     val schedules = _schedules.asStateFlow()
@@ -47,20 +48,21 @@ class CategoryDetailViewModel @Inject constructor(
                     Log.d("PLANJDEBUG", "postSchedule error ${it.message}")
                 }
                 .collect {
-//                    val schedule = Schedule(
-//                        scheduleId = it.data.scheduleUuid,
-//                        categoryName = category,
-//                        title = title,
-//                        endAt = endTime
-//                    )
 
                     //TODO post 성공 후 다시 api 요청하기
                 }
         }
     }
 
-    fun setTitle(title: String) {
-        _title.value = title
+    fun setTitle(category: Category) {
+        _cateogry.value = category
+        viewModelScope.launch{
+            getScheduleInCategory(category)
+        }
+    }
+
+    fun getScheduleInCategory(category : Category){
+        //TODO 카테고리 모든 일정 가져오기
     }
 
     suspend fun getUser() = withContext(Dispatchers.IO) {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailViewModel.kt
@@ -65,10 +65,6 @@ class CategoryDetailViewModel @Inject constructor(
         //TODO 카테고리 모든 일정 가져오기
     }
 
-    suspend fun getUser() = withContext(Dispatchers.IO) {
-        mainRepository.getToken().first()
-    }
-
     fun checkBoxChange(schedule: Schedule, isCheck: Boolean) {
         val calendar = Calendar.getInstance()
         val endTime = schedule.endAt
@@ -85,12 +81,14 @@ class CategoryDetailViewModel @Inject constructor(
     }
 
     fun getCategoryDetailSchedules() {
+        Log.d("PLANJDEBUG", "getCategoryDetailSchedules call")
         viewModelScope.launch {
             mainRepository.getCategorySchedulesApi(_cateogry.value.categoryUuid)
                 .catch {
                     Log.d("PLANJDEBUG", "getCategoryDetailSchedules Error ${it.message}")
                 }.collectLatest {
-                    _schedules.value = it.
+//                    _schedules.value = it
+                    Log.d("PLANJDEBUG", "getCategoryDetailSchedules Success ${it.date}")
                 }
         }
     }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/categorydetail/CategoryDetailViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -30,7 +31,6 @@ class CategoryDetailViewModel @Inject constructor(
 
     private val _schedules = MutableStateFlow<List<Schedule>>(emptyList())
     val schedules = _schedules.asStateFlow()
-
 
 
     fun deleteSchedule(schedule: Schedule) {
@@ -56,12 +56,12 @@ class CategoryDetailViewModel @Inject constructor(
 
     fun setTitle(category: Category) {
         _cateogry.value = category
-        viewModelScope.launch{
+        viewModelScope.launch {
             getScheduleInCategory(category)
         }
     }
 
-    fun getScheduleInCategory(category : Category){
+    fun getScheduleInCategory(category: Category) {
         //TODO 카테고리 모든 일정 가져오기
     }
 
@@ -84,4 +84,14 @@ class CategoryDetailViewModel @Inject constructor(
         val fail = calendar.timeInMillis < System.currentTimeMillis()
     }
 
+    fun getCategoryDetailSchedules() {
+        viewModelScope.launch {
+            mainRepository.getCategorySchedulesApi(_cateogry.value.categoryUuid)
+                .catch {
+                    Log.d("PLANJDEBUG", "getCategoryDetailSchedules Error ${it.message}")
+                }.collectLatest {
+                    _schedules.value = it.
+                }
+        }
+    }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/login/SignInFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/login/SignInFragment.kt
@@ -68,6 +68,15 @@ class SignInFragment : Fragment() {
         binding.viewModel = viewModel
         binding.lifecycleOwner = viewLifecycleOwner
 
+        viewLifecycleOwner.lifecycleScope.launch {
+            val user = viewModel.getToken()
+            if(user.isNotEmpty()){
+                val action = SignInFragmentDirections.actionSignInFragmentToMainActivity()
+                findNavController().navigate(action)
+                requireActivity().finish()
+            }
+        }
+
         NaverIdLoginSDK.initialize(
             requireContext(),
             "${BuildConfig.NAVER_LOGIN_CLIENT_ID}",
@@ -100,14 +109,6 @@ class SignInFragment : Fragment() {
             }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.user.collect { id ->
-                if (id.isNotEmpty()) {
-                    findNavController().navigate(R.id.action_signInFragment_to_mainActivity)
-                    requireActivity().finish()
-                }
-            }
-        }
     }
 
     private fun setListener() {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/login/SignInViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/login/SignInViewModel.kt
@@ -9,13 +9,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -24,9 +22,6 @@ import javax.inject.Inject
 class SignInViewModel @Inject constructor(
     private val loginRepository: LoginRepository
 ) : ViewModel() {
-
-    val user =
-        loginRepository.getUser().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "")
 
     val userEmail = MutableStateFlow("")
     val userPwd = MutableStateFlow("")
@@ -77,5 +72,9 @@ class SignInViewModel @Inject constructor(
                     _showToast.emit("로그인이 완료되었습니다.")
                 }
         }
+    }
+
+    suspend fun getToken() = withContext(Dispatchers.IO){
+        loginRepository.getToken().first()
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/SettingFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/SettingFragment.kt
@@ -45,6 +45,7 @@ class SettingFragment : Fragment() {
     private val pickMedia =
         registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
             if (uri != null) {
+                Log.d("PLANJDEBUG", "url : ${uri.toString()}")
                 val file = File(absolutelyPath(uri, requireContext()))
                 val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull())
                 viewModel.setImageFile(
@@ -54,7 +55,6 @@ class SettingFragment : Fragment() {
                         requestFile
                     )
                 )
-
                 Glide.with(this)
                     .load(uri)
                     .error(R.drawable.ic_circle_person)
@@ -90,17 +90,22 @@ class SettingFragment : Fragment() {
             pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
         }
 
+        binding.ivSettingIconCancel.setOnClickListener {
+            viewModel.getUserImageRemove()
+        }
+
         binding.tvSettingLogout.setOnClickListener {
             runBlocking {
                 viewModel.logoutAccount()
-                val packageManager: PackageManager = requireContext().packageManager
-                val intent = packageManager.getLaunchIntentForPackage(requireContext().packageName)
-                val componentName = intent!!.component
-                val mainIntent = Intent.makeRestartActivityTask(componentName)
-                requireContext().startActivity(mainIntent)
-                activity?.finish()
-
             }
+
+            val packageManager: PackageManager = requireContext().packageManager
+            val intent = packageManager.getLaunchIntentForPackage(requireContext().packageName)
+            val componentName = intent!!.component
+            val mainIntent = Intent.makeRestartActivityTask(componentName)
+            mainIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            activity?.startActivity(mainIntent)
+            activity?.finish()
         }
 
         binding.tvSettingWithdrawal.setOnClickListener {
@@ -110,13 +115,16 @@ class SettingFragment : Fragment() {
                 .setNegativeButton("아니요") { _, _ -> }
                 .setPositiveButton("네") { _, _ ->
                     try {
-                        viewModel.deleteAccount()
+                        runBlocking {
+                            viewModel.deleteAccount()
+                        }
                         val packageManager: PackageManager = requireContext().packageManager
                         val intent =
                             packageManager.getLaunchIntentForPackage(requireContext().packageName)
                         val componentName = intent!!.component
                         val mainIntent = Intent.makeRestartActivityTask(componentName)
-                        requireContext().startActivity(mainIntent)
+                        mainIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                        activity?.startActivity(mainIntent)
                         activity?.finish()
 
                     } catch (e: Exception) {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryClickListener.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryClickListener.kt
@@ -1,5 +1,7 @@
 package com.boostcamp.planj.ui.main.category
 
+import com.boostcamp.planj.data.model.Category
+
 fun interface CategoryClickListener {
-    fun onClick(categoryName: String)
+    fun onClick(category: Category)
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryFragment.kt
@@ -40,6 +40,16 @@ class CategoryFragment : Fragment() {
         viewModel.getCategory()
         initAdapter()
         setObserver()
+
+        binding.layoutCategoryDefault.setOnClickListener {
+            val action = CategoryFragmentDirections.actionCategoryFragmentToCategoryActivity(Category("default", "미분류"))
+            findNavController().navigate(action)
+        }
+
+        binding.layoutCategoryAll.setOnClickListener {
+            val action = CategoryFragmentDirections.actionCategoryFragmentToCategoryActivity(Category("all", "전체 일정"))
+            findNavController().navigate(action)
+        }
     }
 
     private fun setObserver() {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryListAdapterViewHolder.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryListAdapterViewHolder.kt
@@ -20,7 +20,7 @@ class CategoryListAdapterViewHolder(private val binding: ItemListCategoryBinding
         binding.executePendingBindings()
 
         itemView.setOnClickListener {
-            clickListener.onClick(item.categoryName)
+            clickListener.onClick(item)
         }
 
         binding.tvCategoryPopUpMenu.setOnClickListener {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/category/CategoryViewModel.kt
@@ -100,8 +100,4 @@ class CategoryViewModel @Inject constructor(
                 }
         }
     }
-
-    suspend fun getUser() = withContext(Dispatchers.IO) {
-        mainRepository.getToken().first()
-    }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/HomeFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/HomeFragment.kt
@@ -90,8 +90,8 @@ class HomeFragment : Fragment() {
                 HomeFragmentDirections.actionFragmentHomeToScheduleActivity(it.scheduleId)
             findNavController().navigate(action)
         }
-        val checkBoxListener = ScheduleDoneListener { schedule, isCheck ->
-            //viewModel.checkBoxChange(schedule, isCheck)
+        val checkBoxListener = ScheduleDoneListener { schedule ->
+            viewModel.scheduleFinishChange(schedule)
         }
         val segmentScheduleAdapter = SegmentScheduleAdapter(
             swipeListener = swipeListener,

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/HomeFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/HomeFragment.kt
@@ -14,6 +14,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.boostcamp.planj.data.model.Category
 import com.boostcamp.planj.data.model.DateTime
+import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.data.model.ScheduleSegment
 import com.boostcamp.planj.databinding.FragmentHomeBinding
 import com.boostcamp.planj.ui.adapter.ScheduleClickListener
@@ -35,7 +36,6 @@ class HomeFragment : Fragment() {
     private val binding get() = _binding!!
     private val viewModel: MainViewModel by activityViewModels()
 
-    private var categoryList = emptyList<Category>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -76,13 +76,14 @@ class HomeFragment : Fragment() {
         calendar.add(Calendar.DATE, 1 - calendar.get(Calendar.DAY_OF_WEEK))
         val currentDate = SimpleDateFormat("yyyy년 MM월", Locale.getDefault()).format(calendar.time)
         viewModel.setCalendarTitle(currentDate)
-
+        viewModel.getCategories()
         val calendarAdapter = CalendarFragmentStateAdapter(onClickListener, requireActivity())
         initViewPager(calendarAdapter)
 
 
-        val swipeListener = SwipeListener {
-            //viewModel.deleteSchedule(it)
+        val swipeListener = SwipeListener {schedule: Schedule ->
+            viewModel.deleteSchedule(schedule.scheduleId)
+
         }
         val scheduleClickListener = ScheduleClickListener {
             val action =
@@ -101,13 +102,6 @@ class HomeFragment : Fragment() {
         segmentScheduleAdapter.submitList(emptyList())
 
 
-        lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.categories.collectLatest {
-                    categoryList = it.filter { c -> c.categoryName != "전체 일정" }
-                }
-            }
-        }
 
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -165,7 +159,7 @@ class HomeFragment : Fragment() {
     private fun setListener() {
         binding.fbAddSchedule.setOnClickListener {
             val dialog = ScheduleDialog(
-                categoryList.map { it.categoryName },
+                viewModel.categories.value.map{it.categoryName},
                 "미분류"
             ) { category, title, _ ->
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/MainViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/MainViewModel.kt
@@ -47,7 +47,7 @@ class MainViewModel @Inject constructor(
         val dateTime = DateTime(date[0], date[1], date[2], 23, 59)
         viewModelScope.launch(Dispatchers.IO) {
             categories.value.find { it.categoryName == category }?.let { c ->
-                mainRepository.postSchedule("default"/*c.categoryUuid*/, title, dateTime)
+                mainRepository.postSchedule(c.categoryUuid, title, dateTime)
                     .catch {
                         Log.d("PLANJDEBUG", "postSchedule error ${it.message}")
                     }
@@ -84,6 +84,31 @@ class MainViewModel @Inject constructor(
     fun setIsCurrent(position : Int) {
         val now = LocalDate.now()
         _isCurrent.value =  (_selectDate.value == "${now.year}-${String.format("%02d",now.monthValue)}-${String.format("%02d", now.dayOfMonth)}") && (position == Int.MAX_VALUE / 2)
+    }
+
+    fun deleteSchedule(scheduleId:String){
+        viewModelScope.launch {
+            try {
+                mainRepository.deleteScheduleApi(scheduleId)
+                getScheduleDaily("${_selectDate.value}T00:00:00")
+            }catch (e:Exception){
+                Log.d("PLANJDEBUG","deleteSchedule Error ${e.message}")
+            }
+        }
+    }
+
+    fun getCategories(){
+        viewModelScope.launch {
+            mainRepository.getCategoryListApi().catch {
+                Log.d("PLANJDEBUG","getCategories Error ${it.message}")
+            }.collect{
+                Log.d("PLANJDEBUG","getCategories Success $it")
+                val list= it.toMutableList()
+                list.add(0,Category("default","미분류"))
+                _categories.value=list
+            }
+        }
+
     }
 }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/MainViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/home/MainViewModel.kt
@@ -59,7 +59,7 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun getScheduleDaily(date : String){
+    fun getScheduleDaily(date: String) {
         viewModelScope.launch {
             mainRepository.getDailyScheduleApi(date)
                 .catch {
@@ -72,43 +72,64 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun setCalendarTitle(title : String){
+    fun setCalendarTitle(title: String) {
         _calendarTitle.value = title
     }
 
 
-    fun setDate(date : String){
+    fun setDate(date: String) {
         _selectDate.value = date
     }
 
-    fun setIsCurrent(position : Int) {
+    fun setIsCurrent(position: Int) {
         val now = LocalDate.now()
-        _isCurrent.value =  (_selectDate.value == "${now.year}-${String.format("%02d",now.monthValue)}-${String.format("%02d", now.dayOfMonth)}") && (position == Int.MAX_VALUE / 2)
+        _isCurrent.value = (_selectDate.value == "${now.year}-${
+            String.format(
+                "%02d",
+                now.monthValue
+            )
+        }-${String.format("%02d", now.dayOfMonth)}") && (position == Int.MAX_VALUE / 2)
     }
 
-    fun deleteSchedule(scheduleId:String){
+    fun deleteSchedule(scheduleId: String) {
         viewModelScope.launch {
             try {
                 mainRepository.deleteScheduleApi(scheduleId)
                 getScheduleDaily("${_selectDate.value}T00:00:00")
-            }catch (e:Exception){
-                Log.d("PLANJDEBUG","deleteSchedule Error ${e.message}")
+            } catch (e: Exception) {
+                Log.d("PLANJDEBUG", "deleteSchedule Error ${e.message}")
             }
         }
     }
 
-    fun getCategories(){
+    fun getCategories() {
         viewModelScope.launch {
             mainRepository.getCategoryListApi().catch {
-                Log.d("PLANJDEBUG","getCategories Error ${it.message}")
-            }.collect{
-                Log.d("PLANJDEBUG","getCategories Success $it")
-                val list= it.toMutableList()
-                list.add(0,Category("default","미분류"))
-                _categories.value=list
+                Log.d("PLANJDEBUG", "getCategories Error ${it.message}")
+            }.collect {
+                Log.d("PLANJDEBUG", "getCategories Success $it")
+                val list = it.toMutableList()
+                list.add(0, Category("default", "미분류"))
+                _categories.value = list
             }
         }
 
     }
+
+    fun scheduleFinishChange(schedule: Schedule) {
+        viewModelScope.launch {
+            mainRepository.getScheduleChecked(schedule.scheduleId).catch {
+                Log.d("PLANJDEBUG","getScheduleChecked Error ${it.message}")
+            }.collectLatest {
+                if(it.isFail&&!it.isWrite){
+                    //TODO: 일정 실패시 실패이유 작성해야함
+                }
+                getScheduleDaily("${_selectDate.value}T00:00:00")
+            }
+
+        }
+    }
+
+
 }
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -14,6 +14,7 @@ import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.data.model.User
 import com.boostcamp.planj.data.model.dto.PatchScheduleBody
 import com.boostcamp.planj.data.model.naver.NaverResponse
+import com.boostcamp.planj.data.repository.LoginRepository
 import com.boostcamp.planj.data.repository.MainRepository
 import com.boostcamp.planj.data.repository.NaverRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -41,7 +42,8 @@ sealed class AlarmEvent {
 @HiltViewModel
 class ScheduleViewModel @Inject constructor(
     private val mainRepository: MainRepository,
-    private val naverRepository: NaverRepository
+    private val naverRepository: NaverRepository,
+    private val loginRepository: LoginRepository
 ) : ViewModel() {
 
     private lateinit var scheduleId: String
@@ -165,8 +167,8 @@ class ScheduleViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 // 등록된 알림이 있다면 삭제
-                mainRepository.deleteAlarmInfoUsingScheduleId(scheduleId)
-                mainRepository.getAlarmMode().collectLatest { alarmMode ->
+                loginRepository.deleteAlarmInfoUsingScheduleId(scheduleId)
+                loginRepository.getAlarmMode().collectLatest { alarmMode ->
                     if (alarmMode) {
                         _alarmEventFlow.emit(AlarmEvent.Delete(scheduleId))
                     }
@@ -217,8 +219,8 @@ class ScheduleViewModel @Inject constructor(
     private fun setAlarmInfo() {
         if (scheduleAlarm.value == null) {
             viewModelScope.launch {
-                mainRepository.deleteAlarmInfoUsingScheduleId(scheduleId)
-                mainRepository.getAlarmMode().collectLatest { alarmMode ->
+                loginRepository.deleteAlarmInfoUsingScheduleId(scheduleId)
+                loginRepository.getAlarmMode().collectLatest { alarmMode ->
                     if (alarmMode) {
                         _alarmEventFlow.emit(AlarmEvent.Delete(scheduleId))
                     }
@@ -241,8 +243,8 @@ class ScheduleViewModel @Inject constructor(
 
             // db에는 무조건 알람 정보 저장
             viewModelScope.launch {
-                mainRepository.insertAlarmInfo(alarmInfo)
-                mainRepository.getAlarmMode().collectLatest { alarmMode ->
+                loginRepository.insertAlarmInfo(alarmInfo)
+                loginRepository.getAlarmMode().collectLatest { alarmMode ->
                     // 알람 모드 켜져 있을 경우에만 알람매니저를 통해 알람 설정
                     if (alarmMode) {
                         _alarmEventFlow.emit(AlarmEvent.Set(alarmInfo))

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/search/SearchActivity.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/search/SearchActivity.kt
@@ -74,7 +74,7 @@ class SearchActivity : AppCompatActivity() {
             intent.putExtra("schedule", schedule)
             startActivity(intent)
         }
-        scheduleAdapter = ScheduleAdapter(listener, ScheduleDoneListener{ schdeule, isClic -> })
+        scheduleAdapter = ScheduleAdapter(listener, ScheduleDoneListener{ schdeule -> })
         binding.rvSearchScheduleList.adapter = scheduleAdapter
     }
 }

--- a/PlanJ/app/src/main/res/drawable/ic_cancel.xml
+++ b/PlanJ/app/src/main/res/drawable/ic_cancel.xml
@@ -1,0 +1,4 @@
+<vector android:height="20dp" android:viewportHeight="14"
+    android:viewportWidth="14" android:width="20dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/black" android:pathData="M14,1.41L12.59,0L7,5.59L1.41,0L0,1.41L5.59,7L0,12.59L1.41,14L7,8.41L12.59,14L14,12.59L8.41,7L14,1.41Z"/>
+</vector>

--- a/PlanJ/app/src/main/res/layout/fragment_category_detail.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_category_detail.xml
@@ -32,7 +32,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"
-                android:text="@{viewmodel.title}"
+                android:text="@{viewmodel.category.categoryName}"
                 android:textColor="@color/main1"
                 android:textSize="24sp"
                 android:textStyle="bold" />

--- a/PlanJ/app/src/main/res/layout/fragment_setting.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_setting.xml
@@ -99,6 +99,17 @@
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <ImageView
+                    android:id="@+id/iv_setting_icon_cancel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/edit_profile"
+                    android:src="@drawable/ic_cancel"
+                    android:visibility="@{viewModel.isEditMode() ? View.VISIBLE : View.GONE}"
+                    app:layout_constraintTop_toTopOf="@id/iv_setting_img"
+                    app:layout_constraintEnd_toEndOf="@id/iv_setting_img" />
+
+
+                <ImageView
                     android:id="@+id/iv_setting_icon_camera"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -107,6 +118,8 @@
                     android:visibility="@{viewModel.isEditMode() ? View.VISIBLE : View.GONE}"
                     app:layout_constraintBottom_toBottomOf="@id/iv_setting_img"
                     app:layout_constraintEnd_toEndOf="@id/iv_setting_img" />
+
+
 
                 <EditText
                     android:id="@+id/tv_setting_nickname"

--- a/PlanJ/app/src/main/res/navigation/login_nav.xml
+++ b/PlanJ/app/src/main/res/navigation/login_nav.xml
@@ -17,6 +17,8 @@
         tools:layout="@layout/fragment_sign_in">
         <action
             android:id="@+id/action_signInFragment_to_mainActivity"
+            app:popUpToInclusive="true"
+            app:popUpTo="@layout/fragment_home"
             app:destination="@id/mainActivity"
             app:enterAnim="@anim/from_right_to_left" />
         <action

--- a/PlanJ/app/src/main/res/navigation/main_nav.xml
+++ b/PlanJ/app/src/main/res/navigation/main_nav.xml
@@ -43,8 +43,8 @@
         tools:layout="@layout/activity_category"
         >
         <argument
-            android:name="categoryId"
-            app:argType="string" />
+            android:name="category"
+            app:argType="com.boostcamp.planj.data.model.Category" />
     </activity>
     <fragment
         android:id="@+id/fragment_category"

--- a/PlanJ/app/src/main/res/navigation/main_nav.xml
+++ b/PlanJ/app/src/main/res/navigation/main_nav.xml
@@ -23,7 +23,10 @@
         >
         <action
             android:id="@+id/action_fragment_user_to_loginActivity"
-            app:destination="@id/loginActivity" />
+            app:destination="@id/loginActivity"
+            app:popUpTo="@layout/fragment_home"
+            app:popUpToInclusive="true"
+            />
     </fragment>
     <fragment
         android:id="@+id/fragment_friend_list"


### PR DESCRIPTION
+ 일정 라디오, 삭제 api 연결
    + 라디오 경우 체크되면 완료/실패여부를 판단하여 작성글을 쓸  수 있게 만들어야하는데 아직 그 부분은 구현 안함. 일단 체크 했을 때 다시 한번 현재 날짜 api를 쏘아 변경되는 것 까지 확인
    + 삭제 api는 슬라이드 시 삭제되며 화면 갱신까지 잘 작동됨

+ 카테고리 상세 api
    + api 연결까지 가능했지만, 현재 일정 받아오는 데이터와 카테고리 에서 일정 받아오는 api가 달라 백엔드 분이 변경하면 이후에 수행할 예정

+ 설정 프로필 화면 삭제 및 로그인 버그 수정
    + 프로필 수정 시 x 버튼 추가, 이 버튼 클릭 시 이미지 삭제 api 호출, 이후 다시 한 번 유저를 호출하여 변경되는 것을 확인
    + 로그인 시 화면 2번 나오는 버그 수중
        + isSuccess와 token 둘 다 접근하는 경우가 있어서 홈 화면이 2번 나오는 것을 확인 -> token을 observer제거 후 한 번 확인하는 방향으로 변경하고 있을 경우에만 화면 이동하는 방향으로 진행

+ 모듈 분리
    + 로그아웃, 회원탈퇴 후 다시 로그인을 해도 예전 아이디의 토큰이 계속 남아있었다.
        + 추측으로 token은 로그아웃/회원탈퇴 할 때 데이터스토어에서는 잘 지워지는 것을 확인 -> 홈 화면에서 접근할 때 interceptor가 다시 실행되지 않아 예전 토큰 그대로 사용하는 경우가 생가는 것이라 생각
        + 추측이 맞았고 이를 해결하기 위해 MainModule의 시작지점을 늦추는 방향으로 진행
        + 기존 SingletonComponent를 ActivityRetainedComponent로 바꿔 액티비티 클래스에 접근할 때 의존성을 주입하는 방향으로 진행
        + 여기서 생기는 문제점으로 repository에서는 SingletonComponent여서, 그리고 receiver가 application 실행할 때, 즉 SingletonComponent여야 정상 실행 가능한데, ActivityRetainedComponent로 바꾸면 오류가 발생했다.
        + 이를 해결하기 위해 일단 임시로 AalarmReceiver를 mainRepository가 아닌 loginRepository로 옮긴 후 mainRepository, MainModule만 ActivityRetainedComponent 변경할 수 있도록 모듈을 분리하는 작업을 진행
        + 오류를 해결하고 실행한 결과 예전 아이디가 아닌 다시 로그인한 아이디로 접근하는 것을 확인했다.

    + LoginRepository에 alarm 기능과 DataStore, Room의 코드들을 넣었다. 만약 위치가 아닌 것 같다면 이 부분을 따로 분리를 해야할 것  같다.