### PR TITLE
[J033] 반복 설정 변경시 기존 일정 삭제

### DIFF
--- a/be/src/schedule-api/dto/participant.response.ts
+++ b/be/src/schedule-api/dto/participant.response.ts
@@ -1,6 +1,8 @@
 export interface ParticipantResponse {
   nickname: string;
   profileUrl: string;
+  email: string;
+  author: boolean;
   finished: boolean;
   currentUser: boolean;
 }

--- a/be/src/schedule/participate.repository.ts
+++ b/be/src/schedule/participate.repository.ts
@@ -1,5 +1,5 @@
-import { InviteStatus } from "./../utils/domain/invite-status.enum";
-import { Injectable, InternalServerErrorException } from "@nestjs/common";
+import { InviteStatus } from "../utils/domain/invite-status.enum";
+import { Injectable, InternalServerErrorException, Logger } from "@nestjs/common";
 import { Repository, DataSource } from "typeorm";
 import { ParticipantEntity } from "./entity/participant.entity";
 import { ScheduleMetadataEntity } from "./entity/schedule-metadata.entity";
@@ -7,6 +7,7 @@ import { UserEntity } from "src/user/entity/user.entity";
 
 @Injectable()
 export class ParticipateRepository extends Repository<ParticipantEntity> {
+  private readonly logger = new Logger(ParticipateRepository.name);
   constructor(dataSource: DataSource) {
     super(ParticipantEntity, dataSource.createEntityManager());
   }
@@ -26,7 +27,7 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
       await this.save(participantRecord);
       return;
     } catch (error) {
-      console.log(error);
+      this.logger.error(error);
       throw new InternalServerErrorException();
     }
   }
@@ -41,7 +42,7 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
     try {
       await this.softDelete({ authorId: authorMetadataId, participantId: invitedMetadataId });
     } catch (error) {
-      console.log(error);
+      this.logger.error(error);
       throw new InternalServerErrorException();
     }
   }
@@ -82,7 +83,7 @@ export class ParticipateRepository extends Repository<ParticipantEntity> {
       }
     }
 
-    console.log(invitedStatus);
+    this.logger.verbose("Invited Status: " + invitedStatus);
     const invitedStatusArray: [string, InviteStatus][] = Object.entries(invitedStatus);
     return invitedStatusArray;
   }

--- a/be/src/schedule/schedule-location.service.ts
+++ b/be/src/schedule/schedule-location.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException } from "@nestjs/common";
+import { Injectable, InternalServerErrorException, Logger } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { ScheduleMetadataEntity } from "./entity/schedule-metadata.entity";
 import { UpdateScheduleDto } from "./dto/update-schedule.dto";
@@ -7,6 +7,7 @@ import { ScheduleLocationEntity } from "./entity/schedule-location.entity";
 
 @Injectable()
 export class ScheduleLocationService {
+  private readonly logger = new Logger(ScheduleLocationService.name);
   constructor(
     @InjectRepository(ScheduleLocationEntity)
     private scheduleLocationRepository: Repository<ScheduleLocationEntity>,
@@ -66,7 +67,7 @@ export class ScheduleLocationService {
     try {
       await this.scheduleLocationRepository.save(record);
     } catch (error) {
-      console.log(error);
+      this.logger.error(error);
       throw new InternalServerErrorException();
     }
   }

--- a/be/src/schedule/schedule-meta.service.ts
+++ b/be/src/schedule/schedule-meta.service.ts
@@ -41,7 +41,7 @@ export class ScheduleMetaService {
       await this.scheduleMetaRepository.save(scheduleMetadata);
       return scheduleMetadata;
     } catch (error) {
-      console.log(error);
+      this.logger.error(error);
       throw new InternalServerErrorException();
     }
   }
@@ -60,6 +60,10 @@ export class ScheduleMetaService {
 
     if (!record) {
       throw new BadRequestException("해당하는 일정이 없습니다.");
+    }
+
+    if (startAt > endAt) {
+      throw new BadRequestException("종료 시각이 시작 시각보다 빠릅니다.");
     }
 
     record.category = category;

--- a/be/src/schedule/schedule.repository.ts
+++ b/be/src/schedule/schedule.repository.ts
@@ -1,4 +1,4 @@
-import { DataSource, Repository } from "typeorm";
+import { DataSource, MoreThan, Repository } from "typeorm";
 import { Injectable } from "@nestjs/common";
 import { ScheduleEntity } from "./entity/schedule.entity";
 import { DeleteScheduleDto } from "./dto/delete-schedule.dto";
@@ -20,5 +20,13 @@ export class ScheduleRepository extends Repository<ScheduleEntity> {
     await this.softDelete({ scheduleUuid });
 
     return record.metadataId;
+  }
+
+  removeRepeatedSchedules(record: ScheduleEntity) {
+    const { metadataId, endAt } = record;
+    this.softDelete({
+      metadataId: metadataId,
+      endAt: MoreThan(endAt),
+    });
   }
 }


### PR DESCRIPTION
## 완료된 명세
- 반복 설정이 변경되면 해당 일정을 기준으로 이후 반복 일정을 모두 삭제 한 뒤 새로운 반복 일정 추가
- 일정 상세 조회시 공유된 사용자의 이메일 정보, 일정을 생성한 사람이 누구인지 정보 추가