### PR TITLE
[K020] 다이얼로그 네비게이션 연결, 프로필 이미지 변경 관련 오류 수정

### DIFF
--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/dto/MessageResponse.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/model/dto/MessageResponse.kt
@@ -2,6 +2,6 @@ package com.boostcamp.planj.data.model.dto
 
 import com.google.gson.annotations.SerializedName
 
-data class CategoryResponse(
+data class MessageResponse(
     @SerializedName("message") val message: String
 )

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/MainApi.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/network/MainApi.kt
@@ -1,7 +1,6 @@
 package com.boostcamp.planj.data.network
 
 import com.boostcamp.planj.data.model.Category
-import com.boostcamp.planj.data.model.dto.CategoryResponse
 import com.boostcamp.planj.data.model.dto.DeleteFriendBody
 import com.boostcamp.planj.data.model.dto.DeleteScheduleBody
 import com.boostcamp.planj.data.model.dto.GetAlarmResponse
@@ -12,6 +11,7 @@ import com.boostcamp.planj.data.model.dto.GetFriendResponse
 import com.boostcamp.planj.data.model.dto.GetScheduleCheckedResponse
 import com.boostcamp.planj.data.model.dto.GetSchedulesResponse
 import com.boostcamp.planj.data.model.dto.GetUserInfoResponse
+import com.boostcamp.planj.data.model.dto.MessageResponse
 import com.boostcamp.planj.data.model.dto.PatchScheduleBody
 import com.boostcamp.planj.data.model.dto.PatchScheduleResponse
 import com.boostcamp.planj.data.model.dto.PostCategoryBody
@@ -42,7 +42,7 @@ interface MainApi {
     suspend fun postSchedule(@Body postScheduleBody: PostScheduleBody): PostScheduleResponse
 
     @DELETE("/api/category/delete/{categoryUuid}")
-    suspend fun deleteCategory(@Path("categoryUuid") categoryUuid: String): CategoryResponse
+    suspend fun deleteCategory(@Path("categoryUuid") categoryUuid: String): MessageResponse
 
     @HTTP(method = "DELETE", path = "/api/schedule/delete", hasBody = true)
     suspend fun deleteSchedule(@Body deleteScheduleBody: DeleteScheduleBody)
@@ -54,7 +54,7 @@ interface MainApi {
     suspend fun patchSchedule(@Body patchScheduleBody: PatchScheduleBody): PatchScheduleResponse
 
     @PATCH("/api/category/update")
-    suspend fun patchCategory(@Body patchCategoryRequest: Category): CategoryResponse
+    suspend fun patchCategory(@Body patchCategoryRequest: Category): MessageResponse
 
     @GET("/api/category/list")
     suspend fun getCategoryList(): GetCategoryResponse
@@ -62,14 +62,11 @@ interface MainApi {
     @GET("/api/category")
     suspend fun getCategorySchedule(@Query("categoryUuid") categoryUuid: String): GetSchedulesResponse
 
-    @GET("/api/schedule/weekly")
-    suspend fun getWeeklySchedule(@Query("date") date: String): GetSchedulesResponse
-
     @GET("/api/schedule/daily")
     suspend fun getDailySchedule(@Query("date") date: String): GetSchedulesResponse
 
     @POST("/api/friend/add")
-    suspend fun postFriend(@Body postFriendRequest: PostFriendRequest)
+    suspend fun postFriend(@Body postFriendRequest: PostFriendRequest): MessageResponse
 
     @GET("/api/friend")
     suspend fun getFriends(): GetFriendResponse

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepository.kt
@@ -6,10 +6,9 @@ import com.boostcamp.planj.data.model.DateTime
 import com.boostcamp.planj.data.model.FailedMemo
 import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.data.model.User
-import com.boostcamp.planj.data.model.dto.CategoryResponse
 import com.boostcamp.planj.data.model.dto.DeleteFriendBody
 import com.boostcamp.planj.data.model.dto.GetScheduleCheckedResponse
-import com.boostcamp.planj.data.model.dto.GetSchedulesResponse
+import com.boostcamp.planj.data.model.dto.MessageResponse
 import com.boostcamp.planj.data.model.dto.PatchScheduleBody
 import com.boostcamp.planj.data.model.dto.PatchScheduleResponse
 import com.boostcamp.planj.data.model.dto.PostCategoryBody
@@ -33,14 +32,14 @@ interface MainRepository {
 
     suspend fun deleteScheduleApi(scheduleUuid: String)
 
-    suspend fun deleteCategoryApi(categoryUuid: String): Flow<CategoryResponse>
+    suspend fun deleteCategoryApi(categoryUuid: String): Flow<MessageResponse>
 
     fun patchSchedule(patchScheduleBody: PatchScheduleBody): Flow<PatchScheduleResponse>
 
     suspend fun updateCategoryApi(
         categoryUuid: String,
         categoryName: String
-    ): Flow<CategoryResponse>
+    ): Flow<MessageResponse>
 
     fun getCategoryListApi(): Flow<List<Category>>
 
@@ -48,11 +47,11 @@ interface MainRepository {
 
     suspend fun getDailyScheduleApi(date: String): Flow<List<Schedule>>
 
-    suspend fun postFriendApi(friendEmail: String)
+    suspend fun postFriendApi(friendEmail: String): Flow<String>
 
     suspend fun getFriendsApi(): Flow<List<User>>
 
-    suspend fun deleteFriendApi(email: DeleteFriendBody)
+    suspend fun deleteFriendApi(email: String)
 
     suspend fun deleteAccount()
 

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/data/repository/MainRepositoryImpl.kt
@@ -10,11 +10,10 @@ import com.boostcamp.planj.data.model.DateTime
 import com.boostcamp.planj.data.model.FailedMemo
 import com.boostcamp.planj.data.model.Schedule
 import com.boostcamp.planj.data.model.User
-import com.boostcamp.planj.data.model.dto.CategoryResponse
+import com.boostcamp.planj.data.model.dto.MessageResponse
 import com.boostcamp.planj.data.model.dto.DeleteFriendBody
 import com.boostcamp.planj.data.model.dto.DeleteScheduleBody
 import com.boostcamp.planj.data.model.dto.GetScheduleCheckedResponse
-import com.boostcamp.planj.data.model.dto.GetSchedulesResponse
 import com.boostcamp.planj.data.model.dto.PatchScheduleBody
 import com.boostcamp.planj.data.model.dto.PatchScheduleResponse
 import com.boostcamp.planj.data.model.dto.PostCategoryBody
@@ -67,14 +66,14 @@ class MainRepositoryImpl @Inject constructor(
             emit(api.patchSchedule(patchScheduleBody))
         }
 
-    override suspend fun deleteCategoryApi(categoryUuid: String): Flow<CategoryResponse> = flow {
+    override suspend fun deleteCategoryApi(categoryUuid: String): Flow<MessageResponse> = flow {
         emit(api.deleteCategory(categoryUuid))
     }
 
     override suspend fun updateCategoryApi(
         categoryUuid: String,
         categoryName: String
-    ): Flow<CategoryResponse> = flow {
+    ): Flow<MessageResponse> = flow {
         emit(api.patchCategory(Category(categoryUuid, categoryName)))
     }
 
@@ -111,17 +110,17 @@ class MainRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun postFriendApi(friendEmail: String) {
-        api.postFriend(PostFriendRequest(friendEmail))
+    override suspend fun postFriendApi(friendEmail: String): Flow<String> = flow {
+        emit(api.postFriend(PostFriendRequest(friendEmail)).message)
     }
 
     override suspend fun getFriendsApi(): Flow<List<User>> = flow {
         emit(api.getFriends().data)
     }
 
-    override suspend fun deleteFriendApi(email: DeleteFriendBody) {
+    override suspend fun deleteFriendApi(email: String) {
         try {
-            api.deleteFriends(email)
+            api.deleteFriends(DeleteFriendBody(email))
         } catch (e: Exception) {
             Log.d("PLANJDEBUG", "deleteFriendApi ${e.message}")
         }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/BindingAdapter.kt
@@ -101,6 +101,22 @@ fun TextView.setParticipantsNum(participants: List<Participant>) {
     text = participantsNum
 }
 
+@BindingAdapter("completeCount")
+fun TextView.setCompleteCount(schedules: List<Schedule>) {
+    text =
+        schedules.filter { schedule -> schedule.isFinished && !schedule.isFailed }.size.toString()
+}
+
+@BindingAdapter("failCount")
+fun TextView.setFailCount(schedules: List<Schedule>) {
+    text = schedules.filter { schedule -> schedule.isFailed }.size.toString()
+}
+
+@BindingAdapter("remainCount")
+fun TextView.setRemainCount(schedules: List<Schedule>) {
+    text = schedules.filter { schedule -> !schedule.isFinished }.size.toString()
+}
+
 @BindingAdapter("participation")
 fun TextView.setParticipation(schedule: Schedule) {
     if (schedule.participantCount < 2) {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/SettingFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/SettingFragment.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.planj.ui.main
 
+import android.app.Activity
 import android.content.Context
 import android.content.Context.INPUT_METHOD_SERVICE
 import android.content.Intent
@@ -55,6 +56,13 @@ class SettingFragment : Fragment() {
         }
 
     private lateinit var notificationManager: NotificationManagerCompat
+
+    private val getNotificationSettingResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                binding.isAlarmEnable = notificationManager.areNotificationsEnabled()
+            }
+        }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -166,7 +174,7 @@ class SettingFragment : Fragment() {
                 this.putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().packageName)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
-            startActivity(appDetail)
+            getNotificationSettingResult.launch(appDetail)
         }
 
         binding.tvSettingWithdrawal.setOnClickListener {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/SettingFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/SettingFragment.kt
@@ -27,8 +27,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
 import com.boostcamp.planj.R
 import com.boostcamp.planj.databinding.FragmentSettingBinding
-import com.bumptech.glide.Glide
-import com.bumptech.glide.request.RequestOptions
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -49,21 +47,8 @@ class SettingFragment : Fragment() {
     private val pickMedia =
         registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
             if (uri != null) {
-                Log.d("PLANJDEBUG", "url : ${uri.toString()}")
-                val file = File(absolutelyPath(uri, requireContext()))
-                val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull())
-                viewModel.setImageFile(
-                    MultipartBody.Part.createFormData(
-                        "profileImage",
-                        file.name,
-                        requestFile
-                    )
-                )
-                Glide.with(this)
-                    .load(uri)
-                    .error(R.drawable.ic_circle_person)
-                    .apply(RequestOptions.circleCropTransform())
-                    .into(binding.ivSettingImg)
+                Log.d("PLANJDEBUG", "url : ${uri}")
+                viewModel.setUserImg(uri.toString())
             } else {
                 Log.d("PhotoPicker", "No media selected")
             }
@@ -91,7 +76,7 @@ class SettingFragment : Fragment() {
 
         viewModel.setMode()
         viewModel.initUser()
-        viewModel.getTotalSchedules()
+        viewModel.getAllSchedules()
 
         setObserver()
         setListener()
@@ -103,17 +88,6 @@ class SettingFragment : Fragment() {
     }
 
     private fun setObserver() {
-        lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.userInfo.collectLatest { user ->
-                    Glide.with(this@SettingFragment)
-                        .load(user?.profileUrl)
-                        .error(R.drawable.ic_circle_person)
-                        .apply(RequestOptions.circleCropTransform())
-                        .into(binding.ivSettingImg)
-                }
-            }
-        }
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.isEditMode.collectLatest { isMode ->
@@ -155,6 +129,20 @@ class SettingFragment : Fragment() {
                 navOptions { // Use the Kotlin DSL for building NavOptions
 
                 })
+        }
+
+        binding.ivSettingIconCheck.setOnClickListener {
+            viewModel.userImg.value?.let { userImg ->
+                val file = File(absolutelyPath(Uri.parse(userImg), requireContext()))
+                val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull())
+                viewModel.saveUser(
+                    MultipartBody.Part.createFormData(
+                        "profileImage",
+                        file.name,
+                        requestFile
+                    )
+                )
+            } ?: viewModel.saveUser()
         }
 
         binding.tvSettingLogout.setOnClickListener {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/main/friendlist/FriendListViewModel.kt
@@ -41,20 +41,22 @@ class FriendListViewModel @Inject constructor(
 
     fun addUser(email: String) {
         viewModelScope.launch {
-            try {
-                mainRepository.postFriendApi(email)
-                getFriends()
-            } catch (e: Exception) {
-                _showToast.emit("친구 추가를 실패했습니다.")
-                Log.d("PLANJDEBUG", "friendViewModel error ${e.message}")
-            }
+            mainRepository.postFriendApi(email)
+                .catch {
+                    _showToast.emit("친구 추가를 실패했습니다.")
+                    Log.d("PLANJDEBUG", "friendViewModel error ${it.message}")
+                }
+                .collectLatest { message ->
+                    _showToast.emit(message)
+                    getFriends()
+                }
         }
     }
 
     fun deleteUser(email: String) {
         viewModelScope.launch {
             try {
-                mainRepository.deleteFriendApi(DeleteFriendBody(email))
+                mainRepository.deleteFriendApi(email)
                 _showToast.emit("친구 삭제를 완료했습니다.")
                 getFriends()
             } catch (e: Exception) {

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialog.kt
@@ -5,17 +5,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.navArgs
 import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.Alarm
 import com.boostcamp.planj.databinding.DialogAlarmSettingBinding
 
-class AlarmSettingDialog(
-    private val alarm: Alarm?,
-    private val alarmSettingDialogListener: AlarmSettingDialogListener
-) : DialogFragment() {
+class AlarmSettingDialog : DialogFragment() {
 
     private var _binding: DialogAlarmSettingBinding? = null
     private val binding get() = _binding!!
+
+    private val viewModel: ScheduleViewModel by activityViewModels()
+    private val args: AlarmSettingDialogArgs by navArgs()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -32,7 +34,7 @@ class AlarmSettingDialog(
 
         setVisibility()
         setListener()
-        setBtnClicked()
+        setBtnClicked(args.alarmInfo)
     }
 
     override fun onResume() {
@@ -69,15 +71,19 @@ class AlarmSettingDialog(
                 } else if (binding.rbDialogAlarmEnd.isChecked) {
                     Alarm("END", binding.etDialogAlarmBeforeEnd.text.toString().toInt(), 0)
                 } else {
-                    Alarm("DEPARTURE", binding.etDialogAlarmBeforeDeparture.text.toString().toInt(), 0)
+                    Alarm(
+                        "DEPARTURE",
+                        binding.etDialogAlarmBeforeDeparture.text.toString().toInt(),
+                        0
+                    )
                 }
-                alarmSettingDialogListener.onClickComplete(alarm)
+                viewModel.setAlarm(alarm)
                 dismiss()
             }
         }
     }
 
-    private fun setBtnClicked() {
+    private fun setBtnClicked(alarm : Alarm?) {
         with(binding) {
             if (alarm != null && alarm.alarmType == "END") {
                 rbDialogAlarmEnd.isChecked = true

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialogListener.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/AlarmSettingDialogListener.kt
@@ -1,8 +1,0 @@
-package com.boostcamp.planj.ui.schedule
-
-import com.boostcamp.planj.data.model.Alarm
-
-interface AlarmSettingDialogListener {
-
-    fun onClickComplete(alarm: Alarm?)
-}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/RepetitionSettingDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/RepetitionSettingDialog.kt
@@ -5,17 +5,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.navArgs
 import com.boostcamp.planj.R
 import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.databinding.DialogRepetitionSettingBinding
 
-class RepetitionSettingDialog(
-    private val repetition: Repetition?,
-    private val repetitionSettingDialogListener: RepetitionSettingDialogListener
-) : DialogFragment() {
+class RepetitionSettingDialog : DialogFragment() {
 
     private var _binding: DialogRepetitionSettingBinding? = null
     private val binding get() = _binding!!
+
+    private val viewModel: ScheduleViewModel by activityViewModels()
+    private val args: RepetitionSettingDialogArgs by navArgs()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -32,7 +34,7 @@ class RepetitionSettingDialog(
 
         setVisibility()
         setListener()
-        setBtnClicked()
+        setBtnClicked(args.repetitionInfo)
     }
 
     override fun onResume() {
@@ -41,9 +43,9 @@ class RepetitionSettingDialog(
         context?.setDialogSize(this)
     }
 
-    override fun onDestroy() {
+    override fun onDestroyView() {
         _binding = null
-        super.onDestroy()
+        super.onDestroyView()
     }
 
     private fun setVisibility() {
@@ -81,14 +83,14 @@ class RepetitionSettingDialog(
                     } else {
                         Repetition("WEEKLY", etDialogRepetitionWeek.text.toString().toInt())
                     }
-                    repetitionSettingDialogListener.onClickComplete(repetition)
+                    viewModel.setRepetition(repetition)
                     dismiss()
                 }
             }
         }
     }
 
-    private fun setBtnClicked() {
+    private fun setBtnClicked(repetition: Repetition?) {
         with(binding) {
             if (repetition == null) {
                 rbDialogRepetitionNo.isChecked = true

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/RepetitionSettingDialogListener.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/RepetitionSettingDialogListener.kt
@@ -1,8 +1,0 @@
-package com.boostcamp.planj.ui.schedule
-
-import com.boostcamp.planj.data.model.Repetition
-
-interface RepetitionSettingDialogListener {
-
-    fun onClickComplete(repetition: Repetition?)
-}

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleBottomSheetDialog.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleBottomSheetDialog.kt
@@ -4,14 +4,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.navArgs
+import com.boostcamp.planj.data.model.Alarm
 import com.boostcamp.planj.databinding.ScheduleBottomSheetBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class ScheduleBottomSheetDialog(private val time: Int, private val onClick: (Int) -> Unit) :
-    BottomSheetDialogFragment() {
+class ScheduleBottomSheetDialog : BottomSheetDialogFragment() {
     private var _binding: ScheduleBottomSheetBinding? = null
     private val binding get() = _binding!!
 
+    private val args: ScheduleBottomSheetDialogArgs by navArgs()
+    private val viewModel: ScheduleViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -19,8 +23,8 @@ class ScheduleBottomSheetDialog(private val time: Int, private val onClick: (Int
         savedInstanceState: Bundle?
     ): View {
         _binding = ScheduleBottomSheetBinding.inflate(inflater, container, false)
-        return binding.root
 
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -29,6 +33,16 @@ class ScheduleBottomSheetDialog(private val time: Int, private val onClick: (Int
         binding.npScheduleBottom.maxValue = 60
         binding.npScheduleBottom.value = 30
 
+        setText(args.time)
+        setListener()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setText(time: Int) {
         var mTime = time
         val hour = mTime / (1000 * 60 * 60)
         mTime %= (1000 * 60 * 60)
@@ -39,15 +53,12 @@ class ScheduleBottomSheetDialog(private val time: Int, private val onClick: (Int
         } else {
             "소요 시간 ${hour}시 ${min}분"
         }
-
-        binding.btnScheduleBottom.setOnClickListener {
-            onClick(binding.npScheduleBottom.value)
-            dismiss()
-        }
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
+    private fun setListener() {
+        binding.btnScheduleBottom.setOnClickListener {
+            viewModel.setAlarm(Alarm("DEPARTURE", binding.npScheduleBottom.value, 0))
+            dismiss()
+        }
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -31,16 +31,13 @@ import kotlinx.coroutines.launch
 
 
 @AndroidEntryPoint
-class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSettingDialogListener {
+class ScheduleFragment : Fragment() {
 
     private var _binding: FragmentScheduleBinding? = null
     private val binding get() = _binding!!
     private val viewModel: ScheduleViewModel by activityViewModels()
 
     private val args: ScheduleFragmentArgs by navArgs()
-
-    private var repetitionSettingDialog = RepetitionSettingDialog(null, this)
-    private var alarmSettingDialog = AlarmSettingDialog(null, this)
 
     private val datePickerBuilder by lazy {
         MaterialDatePicker.Builder.datePicker()
@@ -73,9 +70,6 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
         binding.fragment = this
         binding.lifecycleOwner = viewLifecycleOwner
 
-//        args.startLocation?.let { viewModel.setStartLocation(it) }
-//        args.endLocation?.let { viewModel.setEndLocation(it) }
-//        args.participants?.let { viewModel.setParticipants(it.toList()) }
         if (args.startLocation != null) {
             viewModel.setStartLocation(args.startLocation!!)
         } else if (args.endLocation != null) {
@@ -204,19 +198,13 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
         }
 
         binding.tvScheduleRepetitionSetting.setOnClickListener {
-            if (!repetitionSettingDialog.isAdded) {
-                repetitionSettingDialog =
-                    RepetitionSettingDialog(viewModel.scheduleRepetition.value, this)
-                repetitionSettingDialog.show(childFragmentManager, "반복 설정")
-            }
+            val action = ScheduleFragmentDirections.actionScheduleFragmentToRepetitionSettingDialog(viewModel.scheduleRepetition.value)
+            findNavController().navigate(action)
         }
 
         binding.tvScheduleAlarmSetting.setOnClickListener {
-            if (!alarmSettingDialog.isAdded) {
-                alarmSettingDialog =
-                    AlarmSettingDialog(viewModel.scheduleAlarm.value, this)
-                alarmSettingDialog.show(childFragmentManager, "알람 설정")
-            }
+            val action = ScheduleFragmentDirections.actionScheduleFragmentToAlarmSettingDialog(viewModel.scheduleAlarm.value)
+            findNavController().navigate(action)
         }
 
         binding.ivScheduleMap.setOnClickListener {
@@ -278,11 +266,8 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
                 if (binding.tvScheduleLocationAlarm.text == "위치 알람 해제") {
                     viewModel.setAlarm(null)
                 } else {
-                    val bottomSheet =
-                        ScheduleBottomSheetDialog(it.route.trafast[0].summary.duration) { min ->
-                            viewModel.setAlarm(Alarm("DEPARTURE", min, 0))
-                        }
-                    bottomSheet.show(childFragmentManager, tag)
+                    val action = ScheduleFragmentDirections.actionScheduleFragmentToScheduleBottomSheetDialog(it.route.trafast[0].summary.duration)
+                    findNavController().navigate(action)
                 }
             }
         }
@@ -342,13 +327,5 @@ class ScheduleFragment : Fragment(), RepetitionSettingDialogListener, AlarmSetti
         timePickerBuilder.setHour(hour)
         timePickerBuilder.setMinute(minute)
         return timePickerBuilder.build()
-    }
-
-    override fun onClickComplete(repetition: Repetition?) {
-        viewModel.setRepetition(repetition)
-    }
-
-    override fun onClickComplete(alarm: Alarm?) {
-        viewModel.setAlarm(alarm)
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -18,8 +18,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.boostcamp.planj.R
-import com.boostcamp.planj.data.model.Alarm
-import com.boostcamp.planj.data.model.Repetition
 import com.boostcamp.planj.databinding.FragmentScheduleBinding
 import com.boostcamp.planj.ui.PlanjAlarm
 import com.google.android.material.datepicker.MaterialDatePicker
@@ -198,12 +196,14 @@ class ScheduleFragment : Fragment() {
         }
 
         binding.tvScheduleRepetitionSetting.setOnClickListener {
-            val action = ScheduleFragmentDirections.actionScheduleFragmentToRepetitionSettingDialog(viewModel.scheduleRepetition.value)
+            val action =
+                ScheduleFragmentDirections.actionScheduleFragmentToRepetitionSettingDialog(viewModel.scheduleRepetition.value)
             findNavController().navigate(action)
         }
 
         binding.tvScheduleAlarmSetting.setOnClickListener {
-            val action = ScheduleFragmentDirections.actionScheduleFragmentToAlarmSettingDialog(viewModel.scheduleAlarm.value)
+            val action =
+                ScheduleFragmentDirections.actionScheduleFragmentToAlarmSettingDialog(viewModel.scheduleAlarm.value)
             findNavController().navigate(action)
         }
 
@@ -266,7 +266,10 @@ class ScheduleFragment : Fragment() {
                 if (binding.tvScheduleLocationAlarm.text == "위치 알람 해제") {
                     viewModel.setAlarm(null)
                 } else {
-                    val action = ScheduleFragmentDirections.actionScheduleFragmentToScheduleBottomSheetDialog(it.route.trafast[0].summary.duration)
+                    val action =
+                        ScheduleFragmentDirections.actionScheduleFragmentToScheduleBottomSheetDialog(
+                            it.route.trafast[0].summary.duration
+                        )
                     findNavController().navigate(action)
                 }
             }
@@ -301,7 +304,7 @@ class ScheduleFragment : Fragment() {
 
     fun setEndTime() {
         var dateMillis = 0L
-        val datePicker = setDatePicker(viewModel.getEndDate())
+        val datePicker = setDatePicker(viewModel.getEndDate() + KST_MILLIS)
         datePicker.show(childFragmentManager, "시작 날짜 설정")
 
         val scheduleEndTime = viewModel.scheduleEndTime.value
@@ -327,5 +330,9 @@ class ScheduleFragment : Fragment() {
         timePickerBuilder.setHour(hour)
         timePickerBuilder.setMinute(minute)
         return timePickerBuilder.build()
+    }
+
+    companion object {
+        const val KST_MILLIS = 1000 * 60 * 60 * 9
     }
 }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.widget.addTextChangedListener
@@ -246,6 +247,14 @@ class ScheduleMapFragment : Fragment(), OnMapReadyCallback {
                             marker.map = naverMap
                         }
                     }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.showToast.collectLatest { message ->
+                    Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
                 }
             }
         }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleMapViewModel.kt
@@ -7,8 +7,10 @@ import com.boostcamp.planj.data.model.Address
 import com.boostcamp.planj.data.model.Location
 import com.boostcamp.planj.data.repository.SearchRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -27,11 +29,15 @@ class ScheduleMapViewModel @Inject constructor(
     private val _searchMap = MutableStateFlow<List<Address>>(emptyList())
     val searchMap: StateFlow<List<Address>> = _searchMap.asStateFlow()
 
+    private val _showToast = MutableSharedFlow<String>()
+    val showToast = _showToast.asSharedFlow()
+
     fun searchMap(query: String) {
         viewModelScope.launch {
             try {
                 _searchMap.value = searchRepository.searchMap(query)
             } catch (e: Exception) {
+                _showToast.emit("검색을 실패했습니다.")
                 Log.d("PLANJDEBUG", "SearchMap Error")
             }
         }

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -331,6 +331,7 @@ class ScheduleViewModel @Inject constructor(
             try {
                 _response.value = naverRepository.getNaverRoute(start, end)
             } catch (e: Exception) {
+                _showToast.emit("경로 찾기를 실패했습니다.")
                 Log.d("PLANJDEBUG", "error ${e.message}")
             }
         }

--- a/PlanJ/app/src/main/res/layout/fragment_setting.xml
+++ b/PlanJ/app/src/main/res/layout/fragment_setting.xml
@@ -85,7 +85,6 @@
                     android:layout_marginTop="24dp"
                     android:layout_marginEnd="24dp"
                     android:contentDescription="@string/edit_profile"
-                    android:onClick="@{() -> viewModel.saveUser()}"
                     android:src="@drawable/ic_check"
                     android:visibility="@{viewModel.isEditMode() ? View.VISIBLE : View.GONE}"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -93,6 +92,7 @@
 
                 <ImageView
                     android:id="@+id/iv_setting_img"
+                    userImg="@{viewModel.userImg}"
                     android:layout_width="150dp"
                     android:layout_height="150dp"
                     android:layout_marginTop="40dp"
@@ -187,10 +187,10 @@
 
                     <TextView
                         android:id="@+id/tv_setting_finish_count"
+                        completeCount="@{viewModel.totalSchedules}"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@{viewModel.completeCount.toString()}"
                         android:textColor="@color/green"
                         android:textSize="16sp"
                         android:textStyle="bold" />
@@ -220,10 +220,10 @@
 
                     <TextView
                         android:id="@+id/tv_setting_fail_count"
+                        failCount="@{viewModel.totalSchedules}"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@{viewModel.failCount.toString()}"
                         android:textColor="@color/red"
                         android:textSize="16sp"
                         android:textStyle="bold" />
@@ -256,10 +256,10 @@
 
                     <TextView
                         android:id="@+id/tv_setting_have_count"
+                        remainCount="@{viewModel.totalSchedules}"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@{viewModel.haveCount.toString()}"
                         android:textColor="@color/text"
                         android:textSize="16sp"
                         android:textStyle="bold" />

--- a/PlanJ/app/src/main/res/menu/toolbar_menu.xml
+++ b/PlanJ/app/src/main/res/menu/toolbar_menu.xml
@@ -4,7 +4,7 @@
 
     <item
         android:id="@+id/alarm"
-        android:icon="@drawable/ic_notifications"
-        android:title="@string/alarm"
+        android:icon="@null"
+        android:title=""
         app:showAsAction="always" />
 </menu>

--- a/PlanJ/app/src/main/res/navigation/schedule_nav.xml
+++ b/PlanJ/app/src/main/res/navigation/schedule_nav.xml
@@ -72,6 +72,32 @@
             android:defaultValue="@null"
             app:argType="com.boostcamp.planj.data.model.Participant[]"
             app:nullable="true" />
+        <action
+            android:id="@+id/action_scheduleFragment_to_repetitionSettingDialog"
+            app:destination="@id/repetitionSettingDialog">
+            <argument
+                android:name="repetitionInfo"
+                android:defaultValue="@null"
+                app:argType="com.boostcamp.planj.data.model.Repetition"
+                app:nullable="true" />
+        </action>
+        <action
+            android:id="@+id/action_scheduleFragment_to_alarmSettingDialog"
+            app:destination="@id/alarmSettingDialog">
+            <argument
+                android:name="alarmInfo"
+                android:defaultValue="@null"
+                app:argType="com.boostcamp.planj.data.model.Alarm"
+                app:nullable="true" />
+        </action>
+        <action
+            android:id="@+id/action_scheduleFragment_to_scheduleBottomSheetDialog"
+            app:destination="@id/scheduleBottomSheetDialog" >
+            <argument
+                android:name="time"
+                app:argType="integer"
+                android:defaultValue="0" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/scheduleMapFragment"
@@ -145,4 +171,33 @@
             android:name="isScheduleEditMode"
             app:argType="boolean" />
     </fragment>
+    <dialog
+        android:id="@+id/repetitionSettingDialog"
+        android:name="com.boostcamp.planj.ui.schedule.RepetitionSettingDialog"
+        android:label="RepetitionSettingDialog">
+        <argument
+            android:name="repetitionInfo"
+            android:defaultValue="@null"
+            app:argType="com.boostcamp.planj.data.model.Repetition"
+            app:nullable="true" />
+    </dialog>
+    <dialog
+        android:id="@+id/alarmSettingDialog"
+        android:name="com.boostcamp.planj.ui.schedule.AlarmSettingDialog"
+        android:label="AlarmSettingDialog">
+        <argument
+            android:name="alarmInfo"
+            android:defaultValue="@null"
+            app:argType="com.boostcamp.planj.data.model.Alarm"
+            app:nullable="true" />
+    </dialog>
+    <dialog
+        android:id="@+id/scheduleBottomSheetDialog"
+        android:name="com.boostcamp.planj.ui.schedule.ScheduleBottomSheetDialog"
+        android:label="ScheduleBottomSheetDialog" >
+        <argument
+            android:name="time"
+            app:argType="integer"
+            android:defaultValue="0" />
+    </dialog>
 </navigation>


### PR DESCRIPTION
### 구현/수정한 기능
- 친구 추가 api  요청 -> 응답 추가
  - 사용자가 자기 자신을 추가할 경우 서버에서 메시지를 보내줌 -> 해당 메시지를 보여주기 위해 리턴값을 추가해주고, 사용자에게 해당 메시지를 토스트로 보여주도록 했다.
- 다이얼로그가 화면에 show했을 떄 -> 화면을 회전하면 어플이 종료되는 exception 발생
  - 다이얼로그들을 navigation graph로 연결하여 해결
- 설정 화면 수정
  - 성공/실패/남은 일정 -> 뷰모델 코드 바인딩 어댑터로 변경
  - 프로필 수정
    - glide를 이용해 해당 이미지를 사용자에게 보여준다 -> Uri는 뷰모델에 저장, 바인딩어댑터에서 glide를 이용해 이미지를 보여주도록 수정
    - Multipart는 서버에 이미지를 전송할 때에만 사용 -> 사용자가 완료버튼을 눌렀을 때에만 생성하도록 변경
  
### 동작 화면
- 자기 자신을 친구로 추가했을 때 토스트
  <img src="https://github.com/boostcampwm2023/and02-PlanJ/assets/101437398/dc029384-bdc8-4692-acd9-1bf400c564e7" width="30%" height="30%" />

### 프로필 이미지 관련 코드 수정
**Setting Fragment**
- 이전
  ```Kotlin
  private val pickMedia = registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
        if (uri != null) {
            val file = File(absolutelyPath(uri, requireContext()))
            val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull())
            viewModel.setImageFile(MultipartBody.Part.createFormData("profileImage", file.name, requestFile))
            Glide.with(this).load(uri).error(R.drawable.ic_circle_person)
                .apply(RequestOptions.circleCropTransform())
                .into(binding.ivSettingImg)
        } 
  ```
- 이후
  ```Kotlin
  private val pickMedia = registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
        if (uri != null) { viewModel.setUserImg(uri.toString()) } 
  
  binding.ivSettingIconCheck.setOnClickListener {
        viewModel.userImg.value?.let { userImg ->
            val file = File(absolutelyPath(Uri.parse(userImg), requireContext()))
            val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull())
            viewModel.saveUser(MultipartBody.Part.createFormData("profileImage",file.name,requestFile))
        } ?: viewModel.saveUser()
    }
  ```