### PR TITLE
[K020] 실패/완료 여부에 따른 메뉴 visibility 조절, 설정 화면 toast 추가

### DIFF
--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleFragment.kt
@@ -101,8 +101,21 @@ class ScheduleFragment : Fragment() {
                 if (isComplete) activity?.finish()
             }
         }
+
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.isAuthor.collectLatest { b ->
+            viewModel.isDeletable.collectLatest { _ ->
+                updateToolbar(viewModel.isEditMode.value)
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.isEditable.collectLatest { _ ->
+                updateToolbar(viewModel.isEditMode.value)
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.isAuthor.collectLatest { _ ->
                 updateToolbar(viewModel.isEditMode.value)
             }
         }
@@ -293,9 +306,9 @@ class ScheduleFragment : Fragment() {
 
     private fun updateToolbar(isEditMode: Boolean) {
         with(binding.toolbarSchedule.menu) {
-            findItem(R.id.item_schedule_edit).isVisible = !isEditMode
-            findItem(R.id.item_schedule_delete).isVisible = (!isEditMode && viewModel.isAuthor.value)
-            findItem(R.id.item_schedule_exit).isVisible = (!isEditMode && !viewModel.isAuthor.value)
+            findItem(R.id.item_schedule_edit).isVisible = (!isEditMode && viewModel.isEditable.value)
+            findItem(R.id.item_schedule_delete).isVisible = (!isEditMode && viewModel.isAuthor.value && viewModel.isDeletable.value)
+            findItem(R.id.item_schedule_exit).isVisible = (!isEditMode && !viewModel.isAuthor.value && viewModel.isDeletable.value)
             findItem(R.id.item_schedule_complete).isVisible = isEditMode
         }
         binding.tvScheduleTop.text = if (!isEditMode) "일정" else "일정 편집"

--- a/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
+++ b/PlanJ/app/src/main/java/com/boostcamp/planj/ui/schedule/ScheduleViewModel.kt
@@ -75,6 +75,12 @@ class ScheduleViewModel @Inject constructor(
     private val _isAuthor = MutableStateFlow(false)
     val isAuthor = _isAuthor.asStateFlow()
 
+    private val _isDeletable = MutableStateFlow(true)
+    val isDeletable = _isDeletable.asStateFlow()
+
+    private val _isEditable = MutableStateFlow(true)
+    val isEditable = _isEditable.asStateFlow()
+
     private val _isFailed = MutableStateFlow(false)
     val isFailed = _isFailed.asStateFlow()
 
@@ -121,8 +127,8 @@ class ScheduleViewModel @Inject constructor(
                     scheduleMemo.value = schedule.description
                     schedule.participants.find { it.currentUser }?.let { currentUser ->
                         _isAuthor.update { currentUser.isAuthor }
-                        _isFailed.update { currentUser.isFailed }
-                        _isFinished.update { currentUser.isFinished }
+                        _isEditable.update { !currentUser.isFailed && !currentUser.isFinished }
+                        _isDeletable.update { !currentUser.isFailed }
                     }
                 }
         }


### PR DESCRIPTION
### 구현한 기능
- 실패/완료 여부에 따른 메뉴 visibility 조절
  - 실패O -> 수정, 삭제 불가능
  - 실패X, 미완료 -> 수정, 삭제 가능
  - 실패X, 완료  -> 삭제만 가능
  - 공유된 일정일 경우
    -> author의 경우 삭제, author가 아닌 참가자이면 해당 일정에서 나가기 처리가 된다. 
- 프로필 수정/삭제 성공 여부에 따른 toast 추가